### PR TITLE
fixes to nft dockerfile to execute successfully

### DIFF
--- a/go/web/skeleton/nft/Dockerfile
+++ b/go/web/skeleton/nft/Dockerfile
@@ -10,11 +10,12 @@ RUN apk add --no-cache ca-certificates && \
     adduser -D -u 12345 -g 12345 k6
 COPY --from=builder /tmp/k6 /usr/bin/k6
 
-USER 12345
 WORKDIR /home/k6
 
-ADD ./resources/load-testing/ /home/k6/load-testing
+ADD ./resources/load-testing/ load-testing
+RUN chmod -R +x load-testing && chown -R 12345:12345 load-testing
 
+USER 12345
 ENV K6_OUT=prometheus
 
 ENTRYPOINT ["k6"]


### PR DESCRIPTION
Created an app out of the template but nft's were failing with `permission denied` on hello.js inside the container. This is to fix that error so we can run them successfully. 