### PR TITLE
Enhancements to java-web from wow-backend

### DIFF
--- a/java/web/skeleton/.gitignore
+++ b/java/web/skeleton/.gitignore
@@ -1,10 +1,23 @@
-*.iml
-.idea
 .gradle
-build
+build/
+!gradle/wrapper/gradle-wrapper.jar
+!**/src/main/**/build/
+!**/src/test/**/build/
 functional/bin
 # Compiled class file
 *.class
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+bin/
+!**/src/main/**/bin/
+!**/src/test/**/bin/
 
 # Log file
 *.log
@@ -20,4 +33,24 @@ db-data/*
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+out/
+!**/src/main/**/out/
+!**/src/test/**/out/
 
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+
+### VS Code ###
+.vscode/
+
+### Cucumber test reports ###
+/target/

--- a/java/web/skeleton/Makefile
+++ b/java/web/skeleton/Makefile
@@ -3,6 +3,7 @@ os := $(shell uname)
 app_name = {{ name }}
 tenant_name = {{ tenant }}
 image_name = $(app_name)
+VERSION ?= $(shell git rev-parse --short HEAD)
 image_tag = $(VERSION)
 helm_test_timeout_duration = 2m
 

--- a/java/web/skeleton/Makefile
+++ b/java/web/skeleton/Makefile
@@ -7,6 +7,9 @@ VERSION ?= $(shell git rev-parse --short HEAD)
 image_tag = $(VERSION)
 helm_test_timeout_duration = 2m
 
+## Default to local registry unless it is set
+REGISTRY ?= local
+
 FAST_FEEDBACK_PATH = fast-feedback
 EXTENDED_TEST_PATH = extended-test
 PROD_PATH = prod

--- a/java/web/skeleton/gradlew.bat
+++ b/java/web/skeleton/gradlew.bat
@@ -43,11 +43,11 @@ set JAVA_EXE=java.exe
 %JAVA_EXE% -version >NUL 2>&1
 if %ERRORLEVEL% equ 0 goto execute
 
-echo.
-echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
-echo.
-echo Please set the JAVA_HOME variable in your environment to match the
-echo location of your Java installation.
+echo. 1>&2
+echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH. 1>&2
+echo. 1>&2
+echo Please set the JAVA_HOME variable in your environment to match the 1>&2
+echo location of your Java installation. 1>&2
 
 goto fail
 
@@ -57,11 +57,11 @@ set JAVA_EXE=%JAVA_HOME%/bin/java.exe
 
 if exist "%JAVA_EXE%" goto execute
 
-echo.
-echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME%
-echo.
-echo Please set the JAVA_HOME variable in your environment to match the
-echo location of your Java installation.
+echo. 1>&2
+echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME% 1>&2
+echo. 1>&2
+echo Please set the JAVA_HOME variable in your environment to match the 1>&2
+echo location of your Java installation. 1>&2
 
 goto fail
 

--- a/java/web/skeleton/settings.gradle
+++ b/java/web/skeleton/settings.gradle
@@ -1,5 +1,6 @@
 rootProject.name = '{{ name }}'
 
 include 'functional'
+include 'nft'
 include 'integration'
 include 'service'


### PR DESCRIPTION
Minor enchancements to the Makefile, gradle and .gitignore files when compared to the wow-backend.

* Makefile: added a default version based on short sha if none set
* gradle enhancement for error logging in windows batch file
* .gitignore ignores build remnants, ide generated files and cucumber test artifacts