### PR TITLE
fix(go-template): fix revive lint-app target and var-naming violations

### DIFF
--- a/go/web/skeleton/Makefile
+++ b/go/web/skeleton/Makefile
@@ -30,7 +30,7 @@ lint-dockerfile: ## Run dockerfile lint checks
 
 .PHONY: lint-app
 lint-app: ## Run app lint checks
-	docker run --rm --mount type=bind,source=.,target=/var/app ghcr.io/mgechev/revive -config /var/app/revive.toml -formatter stylish ./var/app/cmd/service ./var/app/cmd/handler
+	docker run --rm --mount type=bind,source=.,target=/app -w /app docker.io/golang:1.25.4-alpine3.22 sh -c "go install github.com/mgechev/revive@v1.14.0 && revive -config revive.toml -formatter stylish ./cmd/service/... ./cmd/handler/..."
 
 .PHONY: lint
 lint: lint-config lint-dockerfile lint-app ## Run all lint checks

--- a/go/web/skeleton/p2p/tests/functional/functional_test.go
+++ b/go/web/skeleton/p2p/tests/functional/functional_test.go
@@ -12,8 +12,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var baseUri = getBaseURI()
-var ingressBaseUri = getIngressBaseUrl()
+var baseURI = getBaseURI()
+var ingressBaseURI = getIngressBaseURL()
 var request *resty.Request
 var response resty.Response
 
@@ -23,11 +23,11 @@ func aRestService() {
 }
 
 func iCallTheHelloWorldEndpoint() error {
-	log.Printf("Hitting GET endpoint %s\n", baseUri)
-	httpResponse, err := request.Get(baseUri + "/hello")
+	log.Printf("Hitting GET endpoint %s\n", baseURI)
+	httpResponse, err := request.Get(baseURI + "/hello")
 
 	if err != nil {
-		return fmt.Errorf("call to %s was unsuccessful, error: %v", baseUri, err)
+		return fmt.Errorf("call to %s was unsuccessful, error: %v", baseURI, err)
 	}
 
 	response = *httpResponse
@@ -37,10 +37,10 @@ func iCallTheHelloWorldEndpoint() error {
 func iCallTheIngressHelloWorldEndpointAndWaitForItToBeReady() error {
 	successful := false
 	for i := 0; i < 8; i++ {
-		log.Printf(" GET endpoint %s - retry number %d\n", ingressBaseUri, i)
-		httpResponse, err := request.Get(ingressBaseUri + "/hello")
+		log.Printf(" GET endpoint %s - retry number %d\n", ingressBaseURI, i)
+		httpResponse, err := request.Get(ingressBaseURI + "/hello")
 		if err != nil {
-			log.Errorf("call to %s was unsuccessful, error: %v\n Sleeping for 10 seconds to wait for ingress to be available...", ingressBaseUri, err)
+			log.Errorf("call to %s was unsuccessful, error: %v\n Sleeping for 10 seconds to wait for ingress to be available...", ingressBaseURI, err)
 			time.Sleep(10 * time.Second)
 			continue
 		}
@@ -50,7 +50,7 @@ func iCallTheIngressHelloWorldEndpointAndWaitForItToBeReady() error {
 	}
 
 	if !successful {
-		return fmt.Errorf("call to %s was unsuccessful, error: %v", ingressBaseUri, errors.New("unsuccessful call"))
+		return fmt.Errorf("call to %s was unsuccessful, error: %v", ingressBaseURI, errors.New("unsuccessful call"))
 	}
 
 	return nil
@@ -79,7 +79,7 @@ func getBaseURI() string {
 	return serviceEndpoint
 }
 
-func getIngressBaseUrl() string {
+func getIngressBaseURL() string {
 	return os.Getenv("INGRESS_ENDPOINT")
 }
 func TestFeatures(t *testing.T) {

--- a/go/web/skeleton/p2p/tests/integration/integration_test.go
+++ b/go/web/skeleton/p2p/tests/integration/integration_test.go
@@ -12,8 +12,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var baseUri = getBaseURI()
-var ingressBaseUri = getIngressBaseUrl()
+var baseURI = getBaseURI()
+var ingressBaseURI = getIngressBaseURL()
 var request *resty.Request
 var response resty.Response
 
@@ -23,11 +23,11 @@ func aRestService() {
 }
 
 func iCallTheHelloWorldEndpoint() error {
-	log.Printf("Hitting GET endpoint %s\n", baseUri)
-	httpResponse, err := request.Get(baseUri + "/hello")
+	log.Printf("Hitting GET endpoint %s\n", baseURI)
+	httpResponse, err := request.Get(baseURI + "/hello")
 
 	if err != nil {
-		return fmt.Errorf("call to %s was unsuccessful, error: %v", baseUri, err)
+		return fmt.Errorf("call to %s was unsuccessful, error: %v", baseURI, err)
 	}
 
 	response = *httpResponse
@@ -37,10 +37,10 @@ func iCallTheHelloWorldEndpoint() error {
 func iCallTheIngressHelloWorldEndpointAndWaitForItToBeReady() error {
 	successful := false
 	for i := 0; i < 8; i++ {
-		log.Printf(" GET endpoint %s - retry number %d\n", ingressBaseUri, i)
-		httpResponse, err := request.Get(ingressBaseUri + "/hello")
+		log.Printf(" GET endpoint %s - retry number %d\n", ingressBaseURI, i)
+		httpResponse, err := request.Get(ingressBaseURI + "/hello")
 		if err != nil {
-			log.Errorf("call to %s was unsuccessful, error: %v\n Sleeping for 10 seconds to wait for ingress to be available...", ingressBaseUri, err)
+			log.Errorf("call to %s was unsuccessful, error: %v\n Sleeping for 10 seconds to wait for ingress to be available...", ingressBaseURI, err)
 			time.Sleep(10 * time.Second)
 			continue
 		}
@@ -50,7 +50,7 @@ func iCallTheIngressHelloWorldEndpointAndWaitForItToBeReady() error {
 	}
 
 	if !successful {
-		return fmt.Errorf("call to %s was unsuccessful, error: %v", ingressBaseUri, errors.New("unsuccessful call"))
+		return fmt.Errorf("call to %s was unsuccessful, error: %v", ingressBaseURI, errors.New("unsuccessful call"))
 	}
 
 	return nil
@@ -79,7 +79,7 @@ func getBaseURI() string {
 	return serviceEndpoint
 }
 
-func getIngressBaseUrl() string {
+func getIngressBaseURL() string {
 	return os.Getenv("INGRESS_ENDPOINT")
 }
 func TestFeatures(t *testing.T) {


### PR DESCRIPTION
Main issue arose from this:

```
Root Cause

  Revive v1.14.0 (released Feb 10, 2025) introduced a change: "var-naming: improve std package name collision check". This enhancement now requires the go command to load standard library package names. However,
  the revive Docker image is FROM scratch - it contains only the revive binary, no Go toolchain.

  The Makefile uses ghcr.io/mgechev/revive without a version tag (:latest), so when :latest moved from v1.13.0 to v1.14.0, the lint-app target broke:

  cannot configure rule: "var-naming": load std packages: err: go command required, not found

  Proof:
  - ghcr.io/mgechev/revive:v1.13.0 - works fine (exit 0)
  - ghcr.io/mgechev/revive:v1.14.0 / :latest - fails (exit 1)

  Recommended Fix Options

  Option A - Pin to v1.13.0 (quick fix, minimal change):
  ghcr.io/mgechev/revive:v1.13.0
  Pros: one-line change, works immediately. Cons: stuck on old version, same problem will recur eventually.

  Option B - Use go install in a golang Docker image (more reliable):
  lint-app:
        docker run --rm --mount type=bind,source=.,target=/app -w /app \
          docker.io/golang:1.25.4-alpine3.22 \
          sh -c "go install github.com/mgechev/revive@v1.14.0 && revive -config revive.toml -formatter stylish ./cmd/service ./cmd/handler"
  Pros: Go toolchain available, version-pinned, uses same Go image as the build. Cons: slightly slower (installs revive each time, though Docker layer caching helps).

  Option C - Switch to golangci-lint (industry standard):
  Replace revive with golangci-lint (which includes revive as a sub-linter). More comprehensive, widely adopted, has an official Docker image with Go toolchain included.
  ```
  
  I opted for Option B as a quick fix