### PR TITLE
fix(nextjs): align @types/react resolution with devDependencies

### DIFF
--- a/nextjs/web/skeleton/package.json
+++ b/nextjs/web/skeleton/package.json
@@ -42,7 +42,7 @@
     "typescript": "^5.9.3"
   },
   "resolutions": {
-    "@types/react": "19.2.7",
+    "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3"
   }
 }

--- a/nextjs/web/skeleton/yarn.lock
+++ b/nextjs/web/skeleton/yarn.lock
@@ -1560,13 +1560,6 @@
   dependencies:
     csstype "^3.2.2"
 
-"@types/react@19.2.7":
-  version "19.2.7"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-19.2.7.tgz#84e62c0f23e8e4e5ac2cadcea1ffeacccae7f62f"
-  integrity sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==
-  dependencies:
-    csstype "^3.2.2"
-
 "@types/stack-utils@^2.0.3":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.3.tgz#6209321eb2c1712a7e7466422b8cb1fc0d9dd5d8"


### PR DESCRIPTION
## Summary
- The recent dependency update (#100) bumped `@types/react` to `19.2.14` in `devDependencies` but left `resolutions` pinned to `19.2.7`
- This caused yarn to install both versions, with `@types/react-dom` getting a nested copy of `19.2.7`
- TypeScript saw two incompatible `Key` type definitions during `next build`, failing at `button.tsx:48`
- Fix: align `resolutions["@types/react"]` to `19.2.14` and regenerate `yarn.lock`