### PR TITLE
Pass P2P Slack alert secret in templates

### DIFF
--- a/docker/web/skeleton/.github/workflows/extended-test.yaml
+++ b/docker/web/skeleton/.github/workflows/extended-test.yaml
@@ -13,6 +13,8 @@ permissions:
 jobs:
   get-latest-version:
     uses: coreeng/p2p/.github/workflows/p2p-get-latest-image-extended-test.yaml@v1
+    secrets:
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
     with:
       image-name: {{ name }}
 
@@ -20,6 +22,7 @@ jobs:
     needs: [get-latest-version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-extended-test.yaml@v1
     secrets:
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
       env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
     with:
       app-name: {{ name }}

--- a/docker/web/skeleton/.github/workflows/fast-feedback.yaml
+++ b/docker/web/skeleton/.github/workflows/fast-feedback.yaml
@@ -29,11 +29,12 @@ jobs:
       version-prefix: {{ version_prefix }}
     secrets:
       git-token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
-
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
   fastfeedback:
     needs: [version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-fastfeedback.yaml@v1
     secrets:
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
       env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
     with:
       app-name: {{ name }}

--- a/docker/web/skeleton/.github/workflows/prod.yaml
+++ b/docker/web/skeleton/.github/workflows/prod.yaml
@@ -13,6 +13,8 @@ permissions:
 jobs:
   get-latest-version:
     uses: coreeng/p2p/.github/workflows/p2p-get-latest-image-prod.yaml@v1
+    secrets:
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
     with:
       image-name: {{ name }}
 
@@ -20,6 +22,7 @@ jobs:
     needs: [get-latest-version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-prod.yaml@v1
     secrets:
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
       env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
     with:
       app-name: {{ name }}

--- a/go/web/skeleton/.github/workflows/extended-test.yaml
+++ b/go/web/skeleton/.github/workflows/extended-test.yaml
@@ -13,6 +13,8 @@ permissions:
 jobs:
   get-latest-version:
     uses: coreeng/p2p/.github/workflows/p2p-get-latest-image-extended-test.yaml@v1
+    secrets:
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
     with:
       image-name: {{ name }}
 
@@ -20,6 +22,7 @@ jobs:
     needs: [get-latest-version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-extended-test.yaml@v1
     secrets:
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
       env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
     with:
       app-name: {{ name }}

--- a/go/web/skeleton/.github/workflows/fast-feedback.yaml
+++ b/go/web/skeleton/.github/workflows/fast-feedback.yaml
@@ -29,11 +29,12 @@ jobs:
       version-prefix: {{ version_prefix }}
     secrets:
       git-token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
-
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
   fastfeedback:
     needs: [version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-fastfeedback.yaml@v1
     secrets:
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
       env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
     with:
       app-name: {{ name }}

--- a/go/web/skeleton/.github/workflows/prod.yaml
+++ b/go/web/skeleton/.github/workflows/prod.yaml
@@ -13,6 +13,8 @@ permissions:
 jobs:
   get-latest-version:
     uses: coreeng/p2p/.github/workflows/p2p-get-latest-image-prod.yaml@v1
+    secrets:
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
     with:
       image-name: {{ name }}
 
@@ -20,6 +22,7 @@ jobs:
     needs: [get-latest-version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-prod.yaml@v1
     secrets:
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
       env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
     with:
       app-name: {{ name }}

--- a/infra/cloudsql/skeleton/.github/workflows/extended-test.yaml
+++ b/infra/cloudsql/skeleton/.github/workflows/extended-test.yaml
@@ -13,6 +13,8 @@ permissions:
 jobs:
   get-latest-version:
     uses: coreeng/p2p/.github/workflows/p2p-get-latest-image-extended-test.yaml@v1
+    secrets:
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
     with:
       image-name: {{ name }}
 
@@ -20,6 +22,7 @@ jobs:
     needs: [get-latest-version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-extended-test.yaml@v1
     secrets:
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
       env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
     with:
       app-name: {{ name }}

--- a/infra/cloudsql/skeleton/.github/workflows/fast-feedback.yaml
+++ b/infra/cloudsql/skeleton/.github/workflows/fast-feedback.yaml
@@ -29,11 +29,12 @@ jobs:
       version-prefix: {{ version_prefix }}
     secrets:
       git-token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
-
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
   fastfeedback:
     needs: [version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-fastfeedback.yaml@v1
     secrets:
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
       env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
     with:
       app-name: {{ name }}

--- a/infra/cloudsql/skeleton/.github/workflows/prod.yaml
+++ b/infra/cloudsql/skeleton/.github/workflows/prod.yaml
@@ -13,6 +13,8 @@ permissions:
 jobs:
   get-latest-version:
     uses: coreeng/p2p/.github/workflows/p2p-get-latest-image-prod.yaml@v1
+    secrets:
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
     with:
       image-name: {{ name }}
 
@@ -20,6 +22,7 @@ jobs:
     needs: [get-latest-version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-prod.yaml@v1
     secrets:
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
       env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
     with:
       app-name: {{ name }}

--- a/infra/tofu/skeleton/.github/workflows/extended-test.yaml
+++ b/infra/tofu/skeleton/.github/workflows/extended-test.yaml
@@ -13,6 +13,8 @@ permissions:
 jobs:
   get-latest-version:
     uses: coreeng/p2p/.github/workflows/p2p-get-latest-image-extended-test.yaml@v1
+    secrets:
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
     with:
       image-name: {{ name }}
 
@@ -20,6 +22,7 @@ jobs:
     needs: [get-latest-version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-extended-test.yaml@v1
     secrets:
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
       env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
     with:
       app-name: {{ name }}

--- a/infra/tofu/skeleton/.github/workflows/fast-feedback.yaml
+++ b/infra/tofu/skeleton/.github/workflows/fast-feedback.yaml
@@ -29,11 +29,12 @@ jobs:
       version-prefix: {{ version_prefix }}
     secrets:
       git-token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
-
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
   fastfeedback:
     needs: [version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-fastfeedback.yaml@v1
     secrets:
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
       env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
     with:
       app-name: {{ name }}

--- a/infra/tofu/skeleton/.github/workflows/prod.yaml
+++ b/infra/tofu/skeleton/.github/workflows/prod.yaml
@@ -13,6 +13,8 @@ permissions:
 jobs:
   get-latest-version:
     uses: coreeng/p2p/.github/workflows/p2p-get-latest-image-prod.yaml@v1
+    secrets:
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
     with:
       image-name: {{ name }}
 
@@ -20,6 +22,7 @@ jobs:
     needs: [get-latest-version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-prod.yaml@v1
     secrets:
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
       env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
     with:
       app-name: {{ name }}

--- a/infra/urlrouter/skeleton/.github/workflows/extended-test.yaml
+++ b/infra/urlrouter/skeleton/.github/workflows/extended-test.yaml
@@ -13,6 +13,8 @@ permissions:
 jobs:
   get-latest-version:
     uses: coreeng/p2p/.github/workflows/p2p-get-latest-image-extended-test.yaml@v1
+    secrets:
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
     with:
       image-name: {{ name }}
 
@@ -20,6 +22,7 @@ jobs:
     needs: [get-latest-version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-extended-test.yaml@v1
     secrets:
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
       env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
     with:
       app-name: {{ name }}

--- a/infra/urlrouter/skeleton/.github/workflows/fast-feedback.yaml
+++ b/infra/urlrouter/skeleton/.github/workflows/fast-feedback.yaml
@@ -29,11 +29,12 @@ jobs:
       version-prefix: {{ version_prefix }}
     secrets:
       git-token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
-
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
   fastfeedback:
     needs: [version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-fastfeedback.yaml@v1
     secrets:
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
       env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
     with:
       app-name: {{ name }}

--- a/infra/urlrouter/skeleton/.github/workflows/prod.yaml
+++ b/infra/urlrouter/skeleton/.github/workflows/prod.yaml
@@ -13,6 +13,8 @@ permissions:
 jobs:
   get-latest-version:
     uses: coreeng/p2p/.github/workflows/p2p-get-latest-image-prod.yaml@v1
+    secrets:
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
     with:
       image-name: {{ name }}
 
@@ -20,6 +22,7 @@ jobs:
     needs: [get-latest-version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-prod.yaml@v1
     secrets:
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
       env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
     with:
       app-name: {{ name }}

--- a/java/web/skeleton/.github/workflows/extended-test.yaml
+++ b/java/web/skeleton/.github/workflows/extended-test.yaml
@@ -13,6 +13,8 @@ permissions:
 jobs:
   get-latest-version:
     uses: coreeng/p2p/.github/workflows/p2p-get-latest-image-extended-test.yaml@v1
+    secrets:
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
     with:
       image-name: {{ name }}
 
@@ -20,6 +22,7 @@ jobs:
     needs: [get-latest-version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-extended-test.yaml@v1
     secrets:
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
       env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
     with:
       app-name: {{ name }}

--- a/java/web/skeleton/.github/workflows/fast-feedback.yaml
+++ b/java/web/skeleton/.github/workflows/fast-feedback.yaml
@@ -29,11 +29,12 @@ jobs:
       version-prefix: {{ version_prefix }}
     secrets:
       git-token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
-
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
   fastfeedback:
     needs: [version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-fastfeedback.yaml@v1
     secrets:
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
       env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
     with:
       app-name: {{ name }}

--- a/java/web/skeleton/.github/workflows/prod.yaml
+++ b/java/web/skeleton/.github/workflows/prod.yaml
@@ -13,6 +13,8 @@ permissions:
 jobs:
   get-latest-version:
     uses: coreeng/p2p/.github/workflows/p2p-get-latest-image-prod.yaml@v1
+    secrets:
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
     with:
       image-name: {{ name }}
 
@@ -20,6 +22,7 @@ jobs:
     needs: [get-latest-version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-prod.yaml@v1
     secrets:
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
       env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
     with:
       app-name: {{ name }}

--- a/nextjs/web/skeleton/.github/workflows/extended-test.yaml
+++ b/nextjs/web/skeleton/.github/workflows/extended-test.yaml
@@ -13,6 +13,8 @@ permissions:
 jobs:
   get-latest-version:
     uses: coreeng/p2p/.github/workflows/p2p-get-latest-image-extended-test.yaml@v1
+    secrets:
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
     with:
       image-name: {{ name }}
 
@@ -20,6 +22,7 @@ jobs:
     needs: [get-latest-version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-extended-test.yaml@v1
     secrets:
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
       env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
     with:
       app-name: {{ name }}

--- a/nextjs/web/skeleton/.github/workflows/fast-feedback.yaml
+++ b/nextjs/web/skeleton/.github/workflows/fast-feedback.yaml
@@ -29,11 +29,12 @@ jobs:
       version-prefix: {{ version_prefix }}
     secrets:
       git-token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
-
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
   fastfeedback:
     needs: [version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-fastfeedback.yaml@v1
     secrets:
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
       env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
     with:
       app-name: {{ name }}

--- a/nextjs/web/skeleton/.github/workflows/prod.yaml
+++ b/nextjs/web/skeleton/.github/workflows/prod.yaml
@@ -13,6 +13,8 @@ permissions:
 jobs:
   get-latest-version:
     uses: coreeng/p2p/.github/workflows/p2p-get-latest-image-prod.yaml@v1
+    secrets:
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
     with:
       image-name: {{ name }}
 
@@ -20,6 +22,7 @@ jobs:
     needs: [get-latest-version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-prod.yaml@v1
     secrets:
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
       env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
     with:
       app-name: {{ name }}

--- a/python/web/skeleton/.github/workflows/extended-test.yaml
+++ b/python/web/skeleton/.github/workflows/extended-test.yaml
@@ -13,6 +13,8 @@ permissions:
 jobs:
   get-latest-version:
     uses: coreeng/p2p/.github/workflows/p2p-get-latest-image-extended-test.yaml@v1
+    secrets:
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
     with:
       image-name: {{ name }}
 
@@ -20,6 +22,7 @@ jobs:
     needs: [get-latest-version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-extended-test.yaml@v1
     secrets:
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
       env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
     with:
       app-name: {{ name }}

--- a/python/web/skeleton/.github/workflows/fast-feedback.yaml
+++ b/python/web/skeleton/.github/workflows/fast-feedback.yaml
@@ -29,11 +29,12 @@ jobs:
       version-prefix: {{ version_prefix }}
     secrets:
       git-token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
-
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
   fastfeedback:
     needs: [version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-fastfeedback.yaml@v1
     secrets:
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
       env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
     with:
       app-name: {{ name }}

--- a/python/web/skeleton/.github/workflows/prod.yaml
+++ b/python/web/skeleton/.github/workflows/prod.yaml
@@ -13,6 +13,8 @@ permissions:
 jobs:
   get-latest-version:
     uses: coreeng/p2p/.github/workflows/p2p-get-latest-image-prod.yaml@v1
+    secrets:
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
     with:
       image-name: {{ name }}
 
@@ -20,6 +22,7 @@ jobs:
     needs: [get-latest-version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-prod.yaml@v1
     secrets:
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
       env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
     with:
       app-name: {{ name }}

--- a/static/nextra/skeleton/.github/workflows/extended-test.yaml
+++ b/static/nextra/skeleton/.github/workflows/extended-test.yaml
@@ -13,6 +13,8 @@ permissions:
 jobs:
   get-latest-version:
     uses: coreeng/p2p/.github/workflows/p2p-get-latest-image-extended-test.yaml@v1
+    secrets:
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
     with:
       image-name: {{ name }}
 
@@ -20,6 +22,7 @@ jobs:
     needs: [get-latest-version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-extended-test.yaml@v1
     secrets:
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
       env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
     with:
       app-name: {{ name }}

--- a/static/nextra/skeleton/.github/workflows/fast-feedback.yaml
+++ b/static/nextra/skeleton/.github/workflows/fast-feedback.yaml
@@ -29,11 +29,12 @@ jobs:
       version-prefix: {{ version_prefix }}
     secrets:
       git-token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
-
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
   fastfeedback:
     needs: [version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-fastfeedback.yaml@v1
     secrets:
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
       env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
     with:
       app-name: {{ name }}

--- a/static/nextra/skeleton/.github/workflows/prod.yaml
+++ b/static/nextra/skeleton/.github/workflows/prod.yaml
@@ -13,6 +13,8 @@ permissions:
 jobs:
   get-latest-version:
     uses: coreeng/p2p/.github/workflows/p2p-get-latest-image-prod.yaml@v1
+    secrets:
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
     with:
       image-name: {{ name }}
 
@@ -20,6 +22,7 @@ jobs:
     needs: [get-latest-version]
     uses: coreeng/p2p/.github/workflows/p2p-workflow-prod.yaml@v1
     secrets:
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
       env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
     with:
       app-name: {{ name }}


### PR DESCRIPTION
## What
- Pass `secrets.slack_webhook_url` through to all P2P reusable workflow calls in the templates.

## How to enable in apps
- Create repo secret: `P2P_SLACK_WEBHOOK_URL`
- No other changes required.