### PR TITLE
Update get-latest-version workflow inputs

### DIFF
--- a/docker/web/skeleton/.github/workflows/extended-test.yaml
+++ b/docker/web/skeleton/.github/workflows/extended-test.yaml
@@ -17,6 +17,7 @@ jobs:
       slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
     with:
       image-name: {{ name }}
+      tenant-name: {{ tenant }}
 
   extendedtests:
     needs: [get-latest-version]

--- a/docker/web/skeleton/.github/workflows/prod.yaml
+++ b/docker/web/skeleton/.github/workflows/prod.yaml
@@ -17,6 +17,7 @@ jobs:
       slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
     with:
       image-name: {{ name }}
+      tenant-name: {{ tenant }}
 
   prod:
     needs: [get-latest-version]

--- a/go/web/skeleton/.github/workflows/extended-test.yaml
+++ b/go/web/skeleton/.github/workflows/extended-test.yaml
@@ -17,6 +17,7 @@ jobs:
       slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
     with:
       image-name: {{ name }}
+      tenant-name: {{ tenant }}
 
   extendedtests:
     needs: [get-latest-version]

--- a/go/web/skeleton/.github/workflows/prod.yaml
+++ b/go/web/skeleton/.github/workflows/prod.yaml
@@ -17,6 +17,7 @@ jobs:
       slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
     with:
       image-name: {{ name }}
+      tenant-name: {{ tenant }}
 
   prod:
     needs: [get-latest-version]

--- a/infra/cloudsql/skeleton/.github/workflows/extended-test.yaml
+++ b/infra/cloudsql/skeleton/.github/workflows/extended-test.yaml
@@ -17,6 +17,7 @@ jobs:
       slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
     with:
       image-name: {{ name }}
+      tenant-name: {{ tenant }}
 
   extendedtests:
     needs: [get-latest-version]

--- a/infra/cloudsql/skeleton/.github/workflows/prod.yaml
+++ b/infra/cloudsql/skeleton/.github/workflows/prod.yaml
@@ -17,6 +17,7 @@ jobs:
       slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
     with:
       image-name: {{ name }}
+      tenant-name: {{ tenant }}
 
   prod:
     needs: [get-latest-version]

--- a/infra/tofu/skeleton/.github/workflows/extended-test.yaml
+++ b/infra/tofu/skeleton/.github/workflows/extended-test.yaml
@@ -17,6 +17,7 @@ jobs:
       slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
     with:
       image-name: {{ name }}
+      tenant-name: {{ tenant }}
 
   extendedtests:
     needs: [get-latest-version]

--- a/infra/tofu/skeleton/.github/workflows/prod.yaml
+++ b/infra/tofu/skeleton/.github/workflows/prod.yaml
@@ -17,6 +17,7 @@ jobs:
       slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
     with:
       image-name: {{ name }}
+      tenant-name: {{ tenant }}
 
   prod:
     needs: [get-latest-version]

--- a/infra/urlrouter/skeleton/.github/workflows/extended-test.yaml
+++ b/infra/urlrouter/skeleton/.github/workflows/extended-test.yaml
@@ -17,6 +17,7 @@ jobs:
       slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
     with:
       image-name: {{ name }}
+      tenant-name: {{ tenant }}
 
   extendedtests:
     needs: [get-latest-version]

--- a/infra/urlrouter/skeleton/.github/workflows/prod.yaml
+++ b/infra/urlrouter/skeleton/.github/workflows/prod.yaml
@@ -17,6 +17,7 @@ jobs:
       slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
     with:
       image-name: {{ name }}
+      tenant-name: {{ tenant }}
 
   prod:
     needs: [get-latest-version]

--- a/java/web/skeleton/.github/workflows/extended-test.yaml
+++ b/java/web/skeleton/.github/workflows/extended-test.yaml
@@ -17,6 +17,7 @@ jobs:
       slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
     with:
       image-name: {{ name }}
+      tenant-name: {{ tenant }}
 
   extendedtests:
     needs: [get-latest-version]

--- a/java/web/skeleton/.github/workflows/prod.yaml
+++ b/java/web/skeleton/.github/workflows/prod.yaml
@@ -17,6 +17,7 @@ jobs:
       slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
     with:
       image-name: {{ name }}
+      tenant-name: {{ tenant }}
 
   prod:
     needs: [get-latest-version]

--- a/nextjs/web/skeleton/.github/workflows/extended-test.yaml
+++ b/nextjs/web/skeleton/.github/workflows/extended-test.yaml
@@ -17,6 +17,7 @@ jobs:
       slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
     with:
       image-name: {{ name }}
+      tenant-name: {{ tenant }}
 
   extendedtests:
     needs: [get-latest-version]

--- a/nextjs/web/skeleton/.github/workflows/prod.yaml
+++ b/nextjs/web/skeleton/.github/workflows/prod.yaml
@@ -17,6 +17,7 @@ jobs:
       slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
     with:
       image-name: {{ name }}
+      tenant-name: {{ tenant }}
 
   prod:
     needs: [get-latest-version]

--- a/python/web/skeleton/.github/workflows/extended-test.yaml
+++ b/python/web/skeleton/.github/workflows/extended-test.yaml
@@ -17,6 +17,7 @@ jobs:
       slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
     with:
       image-name: {{ name }}
+      tenant-name: {{ tenant }}
 
   extendedtests:
     needs: [get-latest-version]

--- a/python/web/skeleton/.github/workflows/prod.yaml
+++ b/python/web/skeleton/.github/workflows/prod.yaml
@@ -17,6 +17,7 @@ jobs:
       slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
     with:
       image-name: {{ name }}
+      tenant-name: {{ tenant }}
 
   prod:
     needs: [get-latest-version]

--- a/static/nextra/skeleton/.github/workflows/extended-test.yaml
+++ b/static/nextra/skeleton/.github/workflows/extended-test.yaml
@@ -17,6 +17,7 @@ jobs:
       slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
     with:
       image-name: {{ name }}
+      tenant-name: {{ tenant }}
 
   extendedtests:
     needs: [get-latest-version]

--- a/static/nextra/skeleton/.github/workflows/prod.yaml
+++ b/static/nextra/skeleton/.github/workflows/prod.yaml
@@ -17,6 +17,7 @@ jobs:
       slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
     with:
       image-name: {{ name }}
+      tenant-name: {{ tenant }}
 
   prod:
     needs: [get-latest-version]


### PR DESCRIPTION
## Summary
- add the missing `tenant-name` input to the `get-latest-version` job in every template's `extended-test` workflow
- add the missing `tenant-name` input to the `get-latest-version` job in every template's `prod` workflow