### PR TITLE
Scale back extended tests after app template runs

### DIFF
--- a/docker/web/skeleton/Makefile
+++ b/docker/web/skeleton/Makefile
@@ -104,7 +104,7 @@ run-integration:
 
 .PHONY: run-extended-test
 run-extended-test:
-	bash p2p/scripts/helm-test.sh extended "$(p2p_namespace)" "$(p2p_app_name)" false
+	bash p2p/scripts/helm-test.sh extended "$(p2p_namespace)" "$(p2p_app_name)" true
 
 .PHONY: run-%
 run-%:

--- a/go/web/skeleton/Makefile
+++ b/go/web/skeleton/Makefile
@@ -104,7 +104,7 @@ run-integration:
 
 .PHONY: run-extended-test
 run-extended-test:
-	bash p2p/scripts/helm-test.sh extended "$(p2p_namespace)" "$(p2p_app_name)" false
+	bash p2p/scripts/helm-test.sh extended "$(p2p_namespace)" "$(p2p_app_name)" true
 
 .PHONY: run-%
 run-%:

--- a/java/web/skeleton/Makefile
+++ b/java/web/skeleton/Makefile
@@ -104,7 +104,7 @@ run-integration:
 
 .PHONY: run-extended-test
 run-extended-test:
-	bash p2p/scripts/helm-test.sh extended "$(p2p_namespace)" "$(p2p_app_name)" false
+	bash p2p/scripts/helm-test.sh extended "$(p2p_namespace)" "$(p2p_app_name)" true
 
 .PHONY: run-%
 run-%:

--- a/nextjs/web/skeleton/Makefile
+++ b/nextjs/web/skeleton/Makefile
@@ -104,7 +104,7 @@ run-integration:
 
 .PHONY: run-extended-test
 run-extended-test:
-	bash p2p/scripts/helm-test.sh extended "$(p2p_namespace)" "$(p2p_app_name)" false
+	bash p2p/scripts/helm-test.sh extended "$(p2p_namespace)" "$(p2p_app_name)" true
 
 .PHONY: run-%
 run-%:

--- a/python/web/skeleton/Makefile
+++ b/python/web/skeleton/Makefile
@@ -104,7 +104,7 @@ run-integration:
 
 .PHONY: run-extended-test
 run-extended-test:
-	bash p2p/scripts/helm-test.sh extended "$(p2p_namespace)" "$(p2p_app_name)" false
+	bash p2p/scripts/helm-test.sh extended "$(p2p_namespace)" "$(p2p_app_name)" true
 
 .PHONY: run-%
 run-%:

--- a/static/nextra/skeleton/Makefile
+++ b/static/nextra/skeleton/Makefile
@@ -104,7 +104,7 @@ run-integration:
 
 .PHONY: run-extended-test
 run-extended-test:
-	bash p2p/scripts/helm-test.sh extended "$(p2p_namespace)" "$(p2p_app_name)" false
+	bash p2p/scripts/helm-test.sh extended "$(p2p_namespace)" "$(p2p_app_name)" true
 
 .PHONY: run-%
 run-%:


### PR DESCRIPTION
## Summary
- Enable scale-back after extended test runs for every app template.
- Align extended-test `helm-test.sh` calls with functional and NFT behavior.

## Testing
- Verified no app template Makefile still calls `helm-test.sh extended ... false`.