### PR TITLE
Add autoscaling defaults to app templates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -324,15 +324,15 @@ kind: app
 skeletonPath: ./skeleton
 config:
   replicas: 2
-  resources:
-    limits:
-      cpu: 250m      # use 1000m for JVM-based languages
-      memory: 512Mi  # use 1024Mi for JVM-based languages
   autoscaling:
     enabled: true
     minReplicas: 2
     maxReplicas: 8
     targetCPUUtilizationPercentage: 70
+  resources:
+    limits:
+      cpu: 250m      # use 1000m for JVM-based languages
+      memory: 512Mi  # use 1024Mi for JVM-based languages
 ```
 
 #### 2. Copy shared files verbatim from `go/web/skeleton`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ substituted:
 
 App templates (`kind: app`) deploy containerised web services. Each contains:
 
-- `template.yaml` — `kind: app`, replica count, CPU/memory limits
+- `template.yaml` — `kind: app`, replica count, CPU/memory limits, autoscaling defaults
 - `skeleton/Makefile` — P2P targets: `p2p-build`, `p2p-functional`, `p2p-nft`, `p2p-integration`, `p2p-extended-test`, `p2p-prod`
 - `skeleton/.github/workflows/` — `fast-feedback.yaml`, `extended-test.yaml`, `prod.yaml`
 - `skeleton/p2p/config/` — Helm config per P2P stage (`common.yaml` + per-stage overrides)
@@ -328,6 +328,11 @@ config:
     limits:
       cpu: 250m      # use 1000m for JVM-based languages
       memory: 512Mi  # use 1024Mi for JVM-based languages
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 8
+    targetCPUUtilizationPercentage: 70
 ```
 
 #### 2. Copy shared files verbatim from `go/web/skeleton`
@@ -342,10 +347,10 @@ config:
 | `p2p/tests/nft/Dockerfile` | Do not update versions independently of other templates |
 | `p2p/tests/nft/resources/load-testing/hello.js` | |
 | `p2p/tests/nft/resources/load-testing/validate.sh` | |
-| `p2p/config/functional.yaml` | Empty |
+| `p2p/config/functional.yaml` | Disable autoscaling for cleanup stages |
 | `p2p/config/integration.yaml` | Empty |
-| `p2p/config/nft.yaml` | Empty |
-| `p2p/config/extended-test.yaml` | Empty |
+| `p2p/config/nft.yaml` | Disable autoscaling for cleanup stages |
+| `p2p/config/extended-test.yaml` | Disable autoscaling for cleanup stages |
 | `p2p/config/prod.yaml` | Empty |
 
 #### 3. Adapt the Makefile
@@ -360,6 +365,10 @@ Copy from `go/web/skeleton/p2p/config/common.yaml`. The ports are correct for al
 - Liveness probe: port 8081, path `/internal/status`
 - Readiness probe: port 8080, path `/hello`
 - Metrics scraping: port 8081
+
+Autoscaling is configured in `common.yaml` from template config values. Keep autoscaling
+disabled in stages that run post-test scale-down cleanup (`functional`, `nft`, and
+`extended-test`) by setting `autoscaling.enabled: false` in those stage override files.
 
 #### 5. Implement the two-port application
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -328,7 +328,12 @@ config:
     enabled: true
     minReplicas: 2
     maxReplicas: 8
-    targetCPUUtilizationPercentage: 70
+    targetCPUUtilizationPercentage: 80
+    behavior:
+      scaleUp:
+        stabilizationWindowSeconds: 30
+      scaleDown:
+        stabilizationWindowSeconds: 300
   resources:
     limits:
       cpu: 250m      # use 1000m for JVM-based languages
@@ -369,6 +374,7 @@ Copy from `go/web/skeleton/p2p/config/common.yaml`. The ports are correct for al
 Autoscaling is configured in `common.yaml` from template config values. Keep autoscaling
 disabled in stages that run post-test scale-down cleanup (`functional`, `nft`, and
 `extended-test`) by setting `autoscaling.enabled: false` in those stage override files.
+Default HPA behavior stabilizes scale-up for 30 seconds and scale-down for 300 seconds.
 
 #### 5. Implement the two-port application
 

--- a/docker/web/skeleton/p2p/config/common.yaml
+++ b/docker/web/skeleton/p2p/config/common.yaml
@@ -9,6 +9,12 @@ resources:
     cpu: ${p2p_app_config_resources_limits_cpu}
     memory: ${p2p_app_config_resources_limits_memory}
 
+autoscaling:
+  enabled: ${p2p_app_config_autoscaling_enabled}
+  minReplicas: ${p2p_app_config_autoscaling_minReplicas}
+  maxReplicas: ${p2p_app_config_autoscaling_maxReplicas}
+  targetCPUUtilizationPercentage: ${p2p_app_config_autoscaling_targetCPUUtilizationPercentage}
+
 startupProbe:
   failureThreshold: 30
   httpGet:

--- a/docker/web/skeleton/p2p/config/common.yaml
+++ b/docker/web/skeleton/p2p/config/common.yaml
@@ -6,6 +6,11 @@ autoscaling:
   minReplicas: ${p2p_app_config_autoscaling_minReplicas}
   maxReplicas: ${p2p_app_config_autoscaling_maxReplicas}
   targetCPUUtilizationPercentage: ${p2p_app_config_autoscaling_targetCPUUtilizationPercentage}
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: ${p2p_app_config_autoscaling_behavior_scaleUp_stabilizationWindowSeconds}
+    scaleDown:
+      stabilizationWindowSeconds: ${p2p_app_config_autoscaling_behavior_scaleDown_stabilizationWindowSeconds}
 
 resources:
   requests:

--- a/docker/web/skeleton/p2p/config/common.yaml
+++ b/docker/web/skeleton/p2p/config/common.yaml
@@ -1,6 +1,12 @@
 ---
 replicaCount: ${p2p_app_config_replicas}
 
+autoscaling:
+  enabled: ${p2p_app_config_autoscaling_enabled}
+  minReplicas: ${p2p_app_config_autoscaling_minReplicas}
+  maxReplicas: ${p2p_app_config_autoscaling_maxReplicas}
+  targetCPUUtilizationPercentage: ${p2p_app_config_autoscaling_targetCPUUtilizationPercentage}
+
 resources:
   requests:
     cpu: ${p2p_app_config_resources_limits_cpu}
@@ -8,12 +14,6 @@ resources:
   limits:
     cpu: ${p2p_app_config_resources_limits_cpu}
     memory: ${p2p_app_config_resources_limits_memory}
-
-autoscaling:
-  enabled: ${p2p_app_config_autoscaling_enabled}
-  minReplicas: ${p2p_app_config_autoscaling_minReplicas}
-  maxReplicas: ${p2p_app_config_autoscaling_maxReplicas}
-  targetCPUUtilizationPercentage: ${p2p_app_config_autoscaling_targetCPUUtilizationPercentage}
 
 startupProbe:
   failureThreshold: 30

--- a/docker/web/skeleton/p2p/config/extended-test.yaml
+++ b/docker/web/skeleton/p2p/config/extended-test.yaml
@@ -1,1 +1,4 @@
 ---
+# Disable HPA because this stage scales workloads to zero after tests.
+autoscaling:
+  enabled: false

--- a/docker/web/skeleton/p2p/config/functional.yaml
+++ b/docker/web/skeleton/p2p/config/functional.yaml
@@ -1,1 +1,4 @@
 ---
+# Disable HPA because this stage scales workloads to zero after tests.
+autoscaling:
+  enabled: false

--- a/docker/web/skeleton/p2p/config/nft.yaml
+++ b/docker/web/skeleton/p2p/config/nft.yaml
@@ -1,1 +1,4 @@
 ---
+# Disable HPA because this stage scales workloads to zero after tests.
+autoscaling:
+  enabled: false

--- a/docker/web/template.yaml
+++ b/docker/web/template.yaml
@@ -9,7 +9,12 @@ config:
     enabled: true
     minReplicas: 2
     maxReplicas: 8
-    targetCPUUtilizationPercentage: 70
+    targetCPUUtilizationPercentage: 80
+    behavior:
+      scaleUp:
+        stabilizationWindowSeconds: 30
+      scaleDown:
+        stabilizationWindowSeconds: 300
   resources:
     limits:
       cpu: 250m

--- a/docker/web/template.yaml
+++ b/docker/web/template.yaml
@@ -5,12 +5,12 @@ kind: app
 skeletonPath: ./skeleton
 config:
   replicas: 2
-  resources:
-    limits:
-      cpu: 250m
-      memory: 512Mi
   autoscaling:
     enabled: true
     minReplicas: 2
     maxReplicas: 8
     targetCPUUtilizationPercentage: 70
+  resources:
+    limits:
+      cpu: 250m
+      memory: 512Mi

--- a/docker/web/template.yaml
+++ b/docker/web/template.yaml
@@ -9,3 +9,8 @@ config:
     limits:
       cpu: 250m
       memory: 512Mi
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 8
+    targetCPUUtilizationPercentage: 70

--- a/go/web/skeleton/p2p/config/common.yaml
+++ b/go/web/skeleton/p2p/config/common.yaml
@@ -9,6 +9,12 @@ resources:
     cpu: ${p2p_app_config_resources_limits_cpu}
     memory: ${p2p_app_config_resources_limits_memory}
 
+autoscaling:
+  enabled: ${p2p_app_config_autoscaling_enabled}
+  minReplicas: ${p2p_app_config_autoscaling_minReplicas}
+  maxReplicas: ${p2p_app_config_autoscaling_maxReplicas}
+  targetCPUUtilizationPercentage: ${p2p_app_config_autoscaling_targetCPUUtilizationPercentage}
+
 startupProbe:
   failureThreshold: 30
   httpGet:

--- a/go/web/skeleton/p2p/config/common.yaml
+++ b/go/web/skeleton/p2p/config/common.yaml
@@ -6,6 +6,11 @@ autoscaling:
   minReplicas: ${p2p_app_config_autoscaling_minReplicas}
   maxReplicas: ${p2p_app_config_autoscaling_maxReplicas}
   targetCPUUtilizationPercentage: ${p2p_app_config_autoscaling_targetCPUUtilizationPercentage}
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: ${p2p_app_config_autoscaling_behavior_scaleUp_stabilizationWindowSeconds}
+    scaleDown:
+      stabilizationWindowSeconds: ${p2p_app_config_autoscaling_behavior_scaleDown_stabilizationWindowSeconds}
 
 resources:
   requests:

--- a/go/web/skeleton/p2p/config/common.yaml
+++ b/go/web/skeleton/p2p/config/common.yaml
@@ -1,6 +1,12 @@
 ---
 replicaCount: ${p2p_app_config_replicas}
 
+autoscaling:
+  enabled: ${p2p_app_config_autoscaling_enabled}
+  minReplicas: ${p2p_app_config_autoscaling_minReplicas}
+  maxReplicas: ${p2p_app_config_autoscaling_maxReplicas}
+  targetCPUUtilizationPercentage: ${p2p_app_config_autoscaling_targetCPUUtilizationPercentage}
+
 resources:
   requests:
     cpu: ${p2p_app_config_resources_limits_cpu}
@@ -8,12 +14,6 @@ resources:
   limits:
     cpu: ${p2p_app_config_resources_limits_cpu}
     memory: ${p2p_app_config_resources_limits_memory}
-
-autoscaling:
-  enabled: ${p2p_app_config_autoscaling_enabled}
-  minReplicas: ${p2p_app_config_autoscaling_minReplicas}
-  maxReplicas: ${p2p_app_config_autoscaling_maxReplicas}
-  targetCPUUtilizationPercentage: ${p2p_app_config_autoscaling_targetCPUUtilizationPercentage}
 
 startupProbe:
   failureThreshold: 30

--- a/go/web/skeleton/p2p/config/extended-test.yaml
+++ b/go/web/skeleton/p2p/config/extended-test.yaml
@@ -1,1 +1,4 @@
 ---
+# Disable HPA because this stage scales workloads to zero after tests.
+autoscaling:
+  enabled: false

--- a/go/web/skeleton/p2p/config/functional.yaml
+++ b/go/web/skeleton/p2p/config/functional.yaml
@@ -1,1 +1,4 @@
 ---
+# Disable HPA because this stage scales workloads to zero after tests.
+autoscaling:
+  enabled: false

--- a/go/web/skeleton/p2p/config/nft.yaml
+++ b/go/web/skeleton/p2p/config/nft.yaml
@@ -1,1 +1,4 @@
 ---
+# Disable HPA because this stage scales workloads to zero after tests.
+autoscaling:
+  enabled: false

--- a/go/web/template.yaml
+++ b/go/web/template.yaml
@@ -9,7 +9,12 @@ config:
     enabled: true
     minReplicas: 2
     maxReplicas: 8
-    targetCPUUtilizationPercentage: 70
+    targetCPUUtilizationPercentage: 80
+    behavior:
+      scaleUp:
+        stabilizationWindowSeconds: 30
+      scaleDown:
+        stabilizationWindowSeconds: 300
   resources:
     limits:
       cpu: 250m

--- a/go/web/template.yaml
+++ b/go/web/template.yaml
@@ -5,12 +5,12 @@ kind: app
 skeletonPath: ./skeleton
 config:
   replicas: 2
-  resources:
-    limits:
-      cpu: 250m
-      memory: 512Mi
   autoscaling:
     enabled: true
     minReplicas: 2
     maxReplicas: 8
     targetCPUUtilizationPercentage: 70
+  resources:
+    limits:
+      cpu: 250m
+      memory: 512Mi

--- a/go/web/template.yaml
+++ b/go/web/template.yaml
@@ -9,3 +9,8 @@ config:
     limits:
       cpu: 250m
       memory: 512Mi
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 8
+    targetCPUUtilizationPercentage: 70

--- a/java/web/skeleton/p2p/config/common.yaml
+++ b/java/web/skeleton/p2p/config/common.yaml
@@ -9,6 +9,12 @@ resources:
     cpu: ${p2p_app_config_resources_limits_cpu}
     memory: ${p2p_app_config_resources_limits_memory}
 
+autoscaling:
+  enabled: ${p2p_app_config_autoscaling_enabled}
+  minReplicas: ${p2p_app_config_autoscaling_minReplicas}
+  maxReplicas: ${p2p_app_config_autoscaling_maxReplicas}
+  targetCPUUtilizationPercentage: ${p2p_app_config_autoscaling_targetCPUUtilizationPercentage}
+
 startupProbe:
   failureThreshold: 30
   httpGet:

--- a/java/web/skeleton/p2p/config/common.yaml
+++ b/java/web/skeleton/p2p/config/common.yaml
@@ -6,6 +6,11 @@ autoscaling:
   minReplicas: ${p2p_app_config_autoscaling_minReplicas}
   maxReplicas: ${p2p_app_config_autoscaling_maxReplicas}
   targetCPUUtilizationPercentage: ${p2p_app_config_autoscaling_targetCPUUtilizationPercentage}
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: ${p2p_app_config_autoscaling_behavior_scaleUp_stabilizationWindowSeconds}
+    scaleDown:
+      stabilizationWindowSeconds: ${p2p_app_config_autoscaling_behavior_scaleDown_stabilizationWindowSeconds}
 
 resources:
   requests:

--- a/java/web/skeleton/p2p/config/common.yaml
+++ b/java/web/skeleton/p2p/config/common.yaml
@@ -1,6 +1,12 @@
 ---
 replicaCount: ${p2p_app_config_replicas}
 
+autoscaling:
+  enabled: ${p2p_app_config_autoscaling_enabled}
+  minReplicas: ${p2p_app_config_autoscaling_minReplicas}
+  maxReplicas: ${p2p_app_config_autoscaling_maxReplicas}
+  targetCPUUtilizationPercentage: ${p2p_app_config_autoscaling_targetCPUUtilizationPercentage}
+
 resources:
   requests:
     cpu: ${p2p_app_config_resources_limits_cpu}
@@ -8,12 +14,6 @@ resources:
   limits:
     cpu: ${p2p_app_config_resources_limits_cpu}
     memory: ${p2p_app_config_resources_limits_memory}
-
-autoscaling:
-  enabled: ${p2p_app_config_autoscaling_enabled}
-  minReplicas: ${p2p_app_config_autoscaling_minReplicas}
-  maxReplicas: ${p2p_app_config_autoscaling_maxReplicas}
-  targetCPUUtilizationPercentage: ${p2p_app_config_autoscaling_targetCPUUtilizationPercentage}
 
 startupProbe:
   failureThreshold: 30

--- a/java/web/skeleton/p2p/config/extended-test.yaml
+++ b/java/web/skeleton/p2p/config/extended-test.yaml
@@ -1,1 +1,4 @@
 ---
+# Disable HPA because this stage scales workloads to zero after tests.
+autoscaling:
+  enabled: false

--- a/java/web/skeleton/p2p/config/functional.yaml
+++ b/java/web/skeleton/p2p/config/functional.yaml
@@ -1,1 +1,4 @@
 ---
+# Disable HPA because this stage scales workloads to zero after tests.
+autoscaling:
+  enabled: false

--- a/java/web/skeleton/p2p/config/nft.yaml
+++ b/java/web/skeleton/p2p/config/nft.yaml
@@ -1,1 +1,4 @@
 ---
+# Disable HPA because this stage scales workloads to zero after tests.
+autoscaling:
+  enabled: false

--- a/java/web/template.yaml
+++ b/java/web/template.yaml
@@ -9,7 +9,12 @@ config:
     enabled: true
     minReplicas: 2
     maxReplicas: 8
-    targetCPUUtilizationPercentage: 70
+    targetCPUUtilizationPercentage: 80
+    behavior:
+      scaleUp:
+        stabilizationWindowSeconds: 30
+      scaleDown:
+        stabilizationWindowSeconds: 300
   resources:
     limits:
       cpu: 1000m

--- a/java/web/template.yaml
+++ b/java/web/template.yaml
@@ -5,12 +5,12 @@ kind: app
 skeletonPath: ./skeleton
 config:
   replicas: 2
-  resources:
-    limits:
-      cpu: 1000m
-      memory: 1024Mi
   autoscaling:
     enabled: true
     minReplicas: 2
     maxReplicas: 8
     targetCPUUtilizationPercentage: 70
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 1024Mi

--- a/java/web/template.yaml
+++ b/java/web/template.yaml
@@ -9,3 +9,8 @@ config:
     limits:
       cpu: 1000m
       memory: 1024Mi
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 8
+    targetCPUUtilizationPercentage: 70

--- a/nextjs/web/skeleton/p2p/config/common.yaml
+++ b/nextjs/web/skeleton/p2p/config/common.yaml
@@ -9,6 +9,12 @@ resources:
     cpu: ${p2p_app_config_resources_limits_cpu}
     memory: ${p2p_app_config_resources_limits_memory}
 
+autoscaling:
+  enabled: ${p2p_app_config_autoscaling_enabled}
+  minReplicas: ${p2p_app_config_autoscaling_minReplicas}
+  maxReplicas: ${p2p_app_config_autoscaling_maxReplicas}
+  targetCPUUtilizationPercentage: ${p2p_app_config_autoscaling_targetCPUUtilizationPercentage}
+
 startupProbe:
   failureThreshold: 30
   httpGet:

--- a/nextjs/web/skeleton/p2p/config/common.yaml
+++ b/nextjs/web/skeleton/p2p/config/common.yaml
@@ -6,6 +6,11 @@ autoscaling:
   minReplicas: ${p2p_app_config_autoscaling_minReplicas}
   maxReplicas: ${p2p_app_config_autoscaling_maxReplicas}
   targetCPUUtilizationPercentage: ${p2p_app_config_autoscaling_targetCPUUtilizationPercentage}
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: ${p2p_app_config_autoscaling_behavior_scaleUp_stabilizationWindowSeconds}
+    scaleDown:
+      stabilizationWindowSeconds: ${p2p_app_config_autoscaling_behavior_scaleDown_stabilizationWindowSeconds}
 
 resources:
   requests:

--- a/nextjs/web/skeleton/p2p/config/common.yaml
+++ b/nextjs/web/skeleton/p2p/config/common.yaml
@@ -1,6 +1,12 @@
 ---
 replicaCount: ${p2p_app_config_replicas}
 
+autoscaling:
+  enabled: ${p2p_app_config_autoscaling_enabled}
+  minReplicas: ${p2p_app_config_autoscaling_minReplicas}
+  maxReplicas: ${p2p_app_config_autoscaling_maxReplicas}
+  targetCPUUtilizationPercentage: ${p2p_app_config_autoscaling_targetCPUUtilizationPercentage}
+
 resources:
   requests:
     cpu: ${p2p_app_config_resources_limits_cpu}
@@ -8,12 +14,6 @@ resources:
   limits:
     cpu: ${p2p_app_config_resources_limits_cpu}
     memory: ${p2p_app_config_resources_limits_memory}
-
-autoscaling:
-  enabled: ${p2p_app_config_autoscaling_enabled}
-  minReplicas: ${p2p_app_config_autoscaling_minReplicas}
-  maxReplicas: ${p2p_app_config_autoscaling_maxReplicas}
-  targetCPUUtilizationPercentage: ${p2p_app_config_autoscaling_targetCPUUtilizationPercentage}
 
 startupProbe:
   failureThreshold: 30

--- a/nextjs/web/skeleton/p2p/config/extended-test.yaml
+++ b/nextjs/web/skeleton/p2p/config/extended-test.yaml
@@ -1,1 +1,4 @@
 ---
+# Disable HPA because this stage scales workloads to zero after tests.
+autoscaling:
+  enabled: false

--- a/nextjs/web/skeleton/p2p/config/functional.yaml
+++ b/nextjs/web/skeleton/p2p/config/functional.yaml
@@ -1,1 +1,4 @@
 ---
+# Disable HPA because this stage scales workloads to zero after tests.
+autoscaling:
+  enabled: false

--- a/nextjs/web/skeleton/p2p/config/nft.yaml
+++ b/nextjs/web/skeleton/p2p/config/nft.yaml
@@ -1,1 +1,4 @@
 ---
+# Disable HPA because this stage scales workloads to zero after tests.
+autoscaling:
+  enabled: false

--- a/nextjs/web/template.yaml
+++ b/nextjs/web/template.yaml
@@ -9,7 +9,12 @@ config:
     enabled: true
     minReplicas: 2
     maxReplicas: 8
-    targetCPUUtilizationPercentage: 70
+    targetCPUUtilizationPercentage: 80
+    behavior:
+      scaleUp:
+        stabilizationWindowSeconds: 30
+      scaleDown:
+        stabilizationWindowSeconds: 300
   resources:
     limits:
       cpu: 1000m

--- a/nextjs/web/template.yaml
+++ b/nextjs/web/template.yaml
@@ -5,12 +5,12 @@ kind: app
 skeletonPath: ./skeleton
 config:
   replicas: 2
-  resources:
-    limits:
-      cpu: 1000m
-      memory: 1024Mi
   autoscaling:
     enabled: true
     minReplicas: 2
     maxReplicas: 8
     targetCPUUtilizationPercentage: 70
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 1024Mi

--- a/nextjs/web/template.yaml
+++ b/nextjs/web/template.yaml
@@ -9,3 +9,8 @@ config:
     limits:
       cpu: 1000m
       memory: 1024Mi
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 8
+    targetCPUUtilizationPercentage: 70

--- a/python/web/skeleton/p2p/config/common.yaml
+++ b/python/web/skeleton/p2p/config/common.yaml
@@ -9,6 +9,12 @@ resources:
     cpu: ${p2p_app_config_resources_limits_cpu}
     memory: ${p2p_app_config_resources_limits_memory}
 
+autoscaling:
+  enabled: ${p2p_app_config_autoscaling_enabled}
+  minReplicas: ${p2p_app_config_autoscaling_minReplicas}
+  maxReplicas: ${p2p_app_config_autoscaling_maxReplicas}
+  targetCPUUtilizationPercentage: ${p2p_app_config_autoscaling_targetCPUUtilizationPercentage}
+
 startupProbe:
   failureThreshold: 30
   httpGet:

--- a/python/web/skeleton/p2p/config/common.yaml
+++ b/python/web/skeleton/p2p/config/common.yaml
@@ -6,6 +6,11 @@ autoscaling:
   minReplicas: ${p2p_app_config_autoscaling_minReplicas}
   maxReplicas: ${p2p_app_config_autoscaling_maxReplicas}
   targetCPUUtilizationPercentage: ${p2p_app_config_autoscaling_targetCPUUtilizationPercentage}
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: ${p2p_app_config_autoscaling_behavior_scaleUp_stabilizationWindowSeconds}
+    scaleDown:
+      stabilizationWindowSeconds: ${p2p_app_config_autoscaling_behavior_scaleDown_stabilizationWindowSeconds}
 
 resources:
   requests:

--- a/python/web/skeleton/p2p/config/common.yaml
+++ b/python/web/skeleton/p2p/config/common.yaml
@@ -1,6 +1,12 @@
 ---
 replicaCount: ${p2p_app_config_replicas}
 
+autoscaling:
+  enabled: ${p2p_app_config_autoscaling_enabled}
+  minReplicas: ${p2p_app_config_autoscaling_minReplicas}
+  maxReplicas: ${p2p_app_config_autoscaling_maxReplicas}
+  targetCPUUtilizationPercentage: ${p2p_app_config_autoscaling_targetCPUUtilizationPercentage}
+
 resources:
   requests:
     cpu: ${p2p_app_config_resources_limits_cpu}
@@ -8,12 +14,6 @@ resources:
   limits:
     cpu: ${p2p_app_config_resources_limits_cpu}
     memory: ${p2p_app_config_resources_limits_memory}
-
-autoscaling:
-  enabled: ${p2p_app_config_autoscaling_enabled}
-  minReplicas: ${p2p_app_config_autoscaling_minReplicas}
-  maxReplicas: ${p2p_app_config_autoscaling_maxReplicas}
-  targetCPUUtilizationPercentage: ${p2p_app_config_autoscaling_targetCPUUtilizationPercentage}
 
 startupProbe:
   failureThreshold: 30

--- a/python/web/skeleton/p2p/config/extended-test.yaml
+++ b/python/web/skeleton/p2p/config/extended-test.yaml
@@ -1,0 +1,4 @@
+---
+# Disable HPA because this stage scales workloads to zero after tests.
+autoscaling:
+  enabled: false

--- a/python/web/skeleton/p2p/config/functional.yaml
+++ b/python/web/skeleton/p2p/config/functional.yaml
@@ -1,0 +1,4 @@
+---
+# Disable HPA because this stage scales workloads to zero after tests.
+autoscaling:
+  enabled: false

--- a/python/web/skeleton/p2p/config/nft.yaml
+++ b/python/web/skeleton/p2p/config/nft.yaml
@@ -1,0 +1,4 @@
+---
+# Disable HPA because this stage scales workloads to zero after tests.
+autoscaling:
+  enabled: false

--- a/python/web/template.yaml
+++ b/python/web/template.yaml
@@ -9,7 +9,12 @@ config:
     enabled: true
     minReplicas: 2
     maxReplicas: 8
-    targetCPUUtilizationPercentage: 70
+    targetCPUUtilizationPercentage: 80
+    behavior:
+      scaleUp:
+        stabilizationWindowSeconds: 30
+      scaleDown:
+        stabilizationWindowSeconds: 300
   resources:
     limits:
       cpu: 1000m

--- a/python/web/template.yaml
+++ b/python/web/template.yaml
@@ -5,12 +5,12 @@ kind: app
 skeletonPath: ./skeleton
 config:
   replicas: 2
-  resources:
-    limits:
-      cpu: 1000m
-      memory: 1024Mi
   autoscaling:
     enabled: true
     minReplicas: 2
     maxReplicas: 8
     targetCPUUtilizationPercentage: 70
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 1024Mi

--- a/python/web/template.yaml
+++ b/python/web/template.yaml
@@ -9,3 +9,8 @@ config:
     limits:
       cpu: 1000m
       memory: 1024Mi
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 8
+    targetCPUUtilizationPercentage: 70

--- a/schema.yaml
+++ b/schema.yaml
@@ -11,12 +11,12 @@ config: include('config', required=False)
 # Config schema
 config:
   replicas: int(min=0)
-  resources:
-    limits:
-      cpu: str()
-      memory: str()
   autoscaling:
     enabled: bool()
     minReplicas: int(min=1)
     maxReplicas: int(min=1)
     targetCPUUtilizationPercentage: int(min=1, max=100)
+  resources:
+    limits:
+      cpu: str()
+      memory: str()

--- a/schema.yaml
+++ b/schema.yaml
@@ -15,3 +15,8 @@ config:
     limits:
       cpu: str()
       memory: str()
+  autoscaling:
+    enabled: bool()
+    minReplicas: int(min=1)
+    maxReplicas: int(min=1)
+    targetCPUUtilizationPercentage: int(min=1, max=100)

--- a/schema.yaml
+++ b/schema.yaml
@@ -16,6 +16,11 @@ config:
     minReplicas: int(min=1)
     maxReplicas: int(min=1)
     targetCPUUtilizationPercentage: int(min=1, max=100)
+    behavior:
+      scaleUp:
+        stabilizationWindowSeconds: int(min=0)
+      scaleDown:
+        stabilizationWindowSeconds: int(min=0)
   resources:
     limits:
       cpu: str()

--- a/static/nextra/skeleton/p2p/config/common.yaml
+++ b/static/nextra/skeleton/p2p/config/common.yaml
@@ -9,6 +9,12 @@ resources:
     cpu: ${p2p_app_config_resources_limits_cpu}
     memory: ${p2p_app_config_resources_limits_memory}
 
+autoscaling:
+  enabled: ${p2p_app_config_autoscaling_enabled}
+  minReplicas: ${p2p_app_config_autoscaling_minReplicas}
+  maxReplicas: ${p2p_app_config_autoscaling_maxReplicas}
+  targetCPUUtilizationPercentage: ${p2p_app_config_autoscaling_targetCPUUtilizationPercentage}
+
 startupProbe:
   failureThreshold: 30
   httpGet:

--- a/static/nextra/skeleton/p2p/config/common.yaml
+++ b/static/nextra/skeleton/p2p/config/common.yaml
@@ -6,6 +6,11 @@ autoscaling:
   minReplicas: ${p2p_app_config_autoscaling_minReplicas}
   maxReplicas: ${p2p_app_config_autoscaling_maxReplicas}
   targetCPUUtilizationPercentage: ${p2p_app_config_autoscaling_targetCPUUtilizationPercentage}
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: ${p2p_app_config_autoscaling_behavior_scaleUp_stabilizationWindowSeconds}
+    scaleDown:
+      stabilizationWindowSeconds: ${p2p_app_config_autoscaling_behavior_scaleDown_stabilizationWindowSeconds}
 
 resources:
   requests:

--- a/static/nextra/skeleton/p2p/config/common.yaml
+++ b/static/nextra/skeleton/p2p/config/common.yaml
@@ -1,6 +1,12 @@
 ---
 replicaCount: ${p2p_app_config_replicas}
 
+autoscaling:
+  enabled: ${p2p_app_config_autoscaling_enabled}
+  minReplicas: ${p2p_app_config_autoscaling_minReplicas}
+  maxReplicas: ${p2p_app_config_autoscaling_maxReplicas}
+  targetCPUUtilizationPercentage: ${p2p_app_config_autoscaling_targetCPUUtilizationPercentage}
+
 resources:
   requests:
     cpu: ${p2p_app_config_resources_limits_cpu}
@@ -8,12 +14,6 @@ resources:
   limits:
     cpu: ${p2p_app_config_resources_limits_cpu}
     memory: ${p2p_app_config_resources_limits_memory}
-
-autoscaling:
-  enabled: ${p2p_app_config_autoscaling_enabled}
-  minReplicas: ${p2p_app_config_autoscaling_minReplicas}
-  maxReplicas: ${p2p_app_config_autoscaling_maxReplicas}
-  targetCPUUtilizationPercentage: ${p2p_app_config_autoscaling_targetCPUUtilizationPercentage}
 
 startupProbe:
   failureThreshold: 30

--- a/static/nextra/skeleton/p2p/config/extended-test.yaml
+++ b/static/nextra/skeleton/p2p/config/extended-test.yaml
@@ -1,1 +1,4 @@
 ---
+# Disable HPA because this stage scales workloads to zero after tests.
+autoscaling:
+  enabled: false

--- a/static/nextra/skeleton/p2p/config/functional.yaml
+++ b/static/nextra/skeleton/p2p/config/functional.yaml
@@ -1,1 +1,4 @@
 ---
+# Disable HPA because this stage scales workloads to zero after tests.
+autoscaling:
+  enabled: false

--- a/static/nextra/skeleton/p2p/config/nft.yaml
+++ b/static/nextra/skeleton/p2p/config/nft.yaml
@@ -1,1 +1,4 @@
 ---
+# Disable HPA because this stage scales workloads to zero after tests.
+autoscaling:
+  enabled: false

--- a/static/nextra/template.yaml
+++ b/static/nextra/template.yaml
@@ -9,7 +9,12 @@ config:
     enabled: true
     minReplicas: 2
     maxReplicas: 8
-    targetCPUUtilizationPercentage: 70
+    targetCPUUtilizationPercentage: 80
+    behavior:
+      scaleUp:
+        stabilizationWindowSeconds: 30
+      scaleDown:
+        stabilizationWindowSeconds: 300
   resources:
     limits:
       cpu: 1000m

--- a/static/nextra/template.yaml
+++ b/static/nextra/template.yaml
@@ -5,12 +5,12 @@ kind: app
 skeletonPath: ./skeleton
 config:
   replicas: 2
-  resources:
-    limits:
-      cpu: 1000m
-      memory: 1024Mi
   autoscaling:
     enabled: true
     minReplicas: 2
     maxReplicas: 8
     targetCPUUtilizationPercentage: 70
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 1024Mi

--- a/static/nextra/template.yaml
+++ b/static/nextra/template.yaml
@@ -9,3 +9,8 @@ config:
     limits:
       cpu: 1000m
       memory: 1024Mi
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 8
+    targetCPUUtilizationPercentage: 70


### PR DESCRIPTION
## Summary
- Add HPA defaults to every application template with max replicas set to 8.
- Wire HPA configuration, including scale-up and scale-down behavior, through generated common Helm config.
- Disable HPA in cleanup stages and extend template schema/docs for the new autoscaling settings.

## Defaults
- CPU target utilization: 80%
- Scale-up stabilization window: 30s
- Scale-down stabilization window: 300s

## Validation
- make templates-validate
- git diff --check