### PR TITLE
Add config yamllint overrides to templates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -349,6 +349,7 @@ config:
 | `.github/workflows/extended-test.yaml` | |
 | `.github/workflows/prod.yaml` | |
 | `p2p/scripts/helm-test.sh` | |
+| `p2p/config/.yamllint` | Allows generated env variable names in config values |
 | `p2p/tests/nft/Dockerfile` | Do not update versions independently of other templates |
 | `p2p/tests/nft/resources/load-testing/hello.js` | |
 | `p2p/tests/nft/resources/load-testing/validate.sh` | |
@@ -448,7 +449,7 @@ Each contains:
 - `skeleton/Dockerfile` — OpenTofu runner container (the "app" that applies infrastructure)
 - `skeleton/Makefile` — `p2p-build` and `deploy-*` targets; no BDD/NFT/integration test targets
 - `skeleton/.github/workflows/` — `fast-feedback.yaml`, `prod.yaml`
-- `skeleton/p2p/config/` — per-environment config (`common.yaml` + per-stage overrides)
+- `skeleton/p2p/config/` — per-environment config (`common.yaml`, per-stage overrides, `.yamllint`)
 - `skeleton/infrastructure/code/` — OpenTofu modules and Terragrunt configuration
   - `versions.tf` — OpenTofu version constraint and provider versions
   - `.terraform.lock.hcl` — provider lock file (equivalent to `go.sum`); always committed

--- a/go/web/skeleton/p2p/config/.yamllint
+++ b/go/web/skeleton/p2p/config/.yamllint
@@ -1,0 +1,6 @@
+---
+extends: default
+
+rules:
+  line-length:
+    max: 512

--- a/infra/tofu/skeleton/p2p/config/.yamllint
+++ b/infra/tofu/skeleton/p2p/config/.yamllint
@@ -1,0 +1,6 @@
+---
+extends: default
+
+rules:
+  line-length:
+    max: 512

--- a/infra/urlrouter/skeleton/p2p/config/.yamllint
+++ b/infra/urlrouter/skeleton/p2p/config/.yamllint
@@ -1,0 +1,6 @@
+---
+extends: default
+
+rules:
+  line-length:
+    max: 512

--- a/java/web/skeleton/p2p/config/.yamllint
+++ b/java/web/skeleton/p2p/config/.yamllint
@@ -1,0 +1,6 @@
+---
+extends: default
+
+rules:
+  line-length:
+    max: 512

--- a/nextjs/web/skeleton/p2p/config/.yamllint
+++ b/nextjs/web/skeleton/p2p/config/.yamllint
@@ -1,0 +1,6 @@
+---
+extends: default
+
+rules:
+  line-length:
+    max: 512

--- a/python/web/skeleton/p2p/config/.yamllint
+++ b/python/web/skeleton/p2p/config/.yamllint
@@ -1,0 +1,6 @@
+---
+extends: default
+
+rules:
+  line-length:
+    max: 512

--- a/static/nextra/skeleton/p2p/config/.yamllint
+++ b/static/nextra/skeleton/p2p/config/.yamllint
@@ -1,0 +1,6 @@
+---
+extends: default
+
+rules:
+  line-length:
+    max: 512


### PR DESCRIPTION
## Summary
- Add `p2p/config/.yamllint` to app and infra templates missing the generated config lint override.
- Keep config lint line-length handling consistent across all templates.
- Update template docs to mention the generated config yamllint file.

## Validation
- make templates-validate
- docker run --rm --mount type=bind,source=./go/web/skeleton/p2p/config,target=/data docker.io/cytopia/yamllint -s .
- docker run --rm --mount type=bind,source=./infra/tofu/skeleton/p2p/config,target=/data docker.io/cytopia/yamllint -s .
- git diff --check