### PR TITLE
Trigger all reference app template renders

### DIFF
--- a/docker/web/skeleton/README.md
+++ b/docker/web/skeleton/README.md
@@ -1,5 +1,6 @@
 # {{ name }}
 
+
 Docker web application for Core Platform
 
 # Parameters
@@ -137,4 +138,3 @@ Extended Test are using [Cucumber Godog](https://github.com/cucumber/godog)
 
 This namespace is used to test that the individual parts of the system as well as service-to-service communication
 of the app works correctly against real dependencies. Currently, using BDD (Behaviour driven development)
-

--- a/go/web/skeleton/README.md
+++ b/go/web/skeleton/README.md
@@ -1,5 +1,6 @@
 # {{ name }}
 
+
 Go web application for Core Platform
 
 # Parameters
@@ -204,4 +205,3 @@ betaFeatures:
 When running load tests it is important that we define CPU resource limits. This will allow us to have stable results between runs.
 
 If we don't apply the limits then the performance of the Pods will depend on the CPU utilization of the node that is running the container.
-

--- a/infra/cloudsql/skeleton/README.md
+++ b/infra/cloudsql/skeleton/README.md
@@ -1,4 +1,4 @@
 # {{ name }}
 
-Infrastructure provisioning application for Core Platform
 
+Infrastructure provisioning application for Core Platform

--- a/infra/tofu/skeleton/README.md
+++ b/infra/tofu/skeleton/README.md
@@ -1,4 +1,4 @@
 # {{ name }}
 
-Infrastructure provisioning application for Core Platform
 
+Infrastructure provisioning application for Core Platform

--- a/infra/urlrouter/skeleton/README.md
+++ b/infra/urlrouter/skeleton/README.md
@@ -1,4 +1,4 @@
 # {{ name }}
 
-Infrastructure provisioning application for Core Platform
 
+Infrastructure provisioning application for Core Platform

--- a/java/web/skeleton/README.md
+++ b/java/web/skeleton/README.md
@@ -1,5 +1,6 @@
 # {{ name }}
 
+
 Java web application for Core Platform
 
 # Parameters
@@ -204,4 +205,3 @@ betaFeatures:
 When running load tests it is important that we define CPU resource limits. This will allow us to have stable results between runs.
 
 If we don't apply the limits then the performance of the Pods will depend on the CPU utilization of the node that is running the container.
-

--- a/nextjs/web/skeleton/README.md
+++ b/nextjs/web/skeleton/README.md
@@ -1,5 +1,6 @@
 # {{ name }}
 
+
 Next.js web application for Core Platform
 
 # Parameters
@@ -204,4 +205,3 @@ betaFeatures:
 When running load tests it is important that we define CPU resource limits. This will allow us to have stable results between runs.
 
 If we don't apply the limits then the performance of the Pods will depend on the CPU utilization of the node that is running the container.
-

--- a/python/web/skeleton/README.md
+++ b/python/web/skeleton/README.md
@@ -1,5 +1,6 @@
 # {{ name }}
 
+
 Python web application for Core Platform
 
 ## Overview
@@ -120,4 +121,3 @@ A Grafana dashboard is available via the internal services domain once the app i
 ### K6 Operator
 
 The NFT and Extended test stages use the K6 Operator on the cluster. The custom K6 build includes the [xk6-prometheus](https://github.com/coreeng/xk6-prometheus) extension so metrics are exported to Prometheus during load tests.
-

--- a/static/nextra/skeleton/README.md
+++ b/static/nextra/skeleton/README.md
@@ -1,5 +1,6 @@
 # {{ name }}
 
+
 Nextra docs application for Core Platform
 
 # Parameters
@@ -204,4 +205,3 @@ betaFeatures:
 When running load tests it is important that we define CPU resource limits. This will allow us to have stable results between runs.
 
 If we don't apply the limits then the performance of the Pods will depend on the CPU utilization of the node that is running the container.
-


### PR DESCRIPTION
## Summary
- Move the README whitespace trigger from EOF to an interior blank line after each template title.
- This should create a rendered README diff for every reference application template.

## Validation
- Rendered all nine templates locally with `corectl template render` and confirmed each output README preserves the interior blank line.
- `git diff --check` passes.

## Context
The previous EOF-only blank-line change only resulted in `python-web` rendering because EOF whitespace did not produce rendered README diffs for the other templates.