### PR TITLE
Remove reference app render trigger spacing

### DIFF
--- a/docker/web/skeleton/README.md
+++ b/docker/web/skeleton/README.md
@@ -1,6 +1,5 @@
 # {{ name }}
 
-
 Docker web application for Core Platform
 
 # Parameters

--- a/go/web/skeleton/README.md
+++ b/go/web/skeleton/README.md
@@ -1,6 +1,5 @@
 # {{ name }}
 
-
 Go web application for Core Platform
 
 # Parameters

--- a/infra/cloudsql/skeleton/README.md
+++ b/infra/cloudsql/skeleton/README.md
@@ -1,4 +1,3 @@
 # {{ name }}
 
-
 Infrastructure provisioning application for Core Platform

--- a/infra/tofu/skeleton/README.md
+++ b/infra/tofu/skeleton/README.md
@@ -1,4 +1,3 @@
 # {{ name }}
 
-
 Infrastructure provisioning application for Core Platform

--- a/infra/urlrouter/skeleton/README.md
+++ b/infra/urlrouter/skeleton/README.md
@@ -1,4 +1,3 @@
 # {{ name }}
 
-
 Infrastructure provisioning application for Core Platform

--- a/java/web/skeleton/README.md
+++ b/java/web/skeleton/README.md
@@ -1,6 +1,5 @@
 # {{ name }}
 
-
 Java web application for Core Platform
 
 # Parameters

--- a/nextjs/web/skeleton/README.md
+++ b/nextjs/web/skeleton/README.md
@@ -1,6 +1,5 @@
 # {{ name }}
 
-
 Next.js web application for Core Platform
 
 # Parameters

--- a/python/web/skeleton/README.md
+++ b/python/web/skeleton/README.md
@@ -1,6 +1,5 @@
 # {{ name }}
 
-
 Python web application for Core Platform
 
 ## Overview

--- a/static/nextra/skeleton/README.md
+++ b/static/nextra/skeleton/README.md
@@ -1,6 +1,5 @@
 # {{ name }}
 
-
 Nextra docs application for Core Platform
 
 # Parameters


### PR DESCRIPTION
## Summary
- Remove the temporary extra blank line added after each template README title.

## Validation
- Confirmed the diff is limited to removing that blank line from each template README.
- `git diff --check` passes.