### PR TITLE
Add resource requests to app templates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ substituted:
 
 App templates (`kind: app`) deploy containerised web services. Each contains:
 
-- `template.yaml` — `kind: app`, replica count, CPU/memory limits, autoscaling defaults
+- `template.yaml` — `kind: app`, replica count, CPU/memory requests and limits, autoscaling defaults
 - `skeleton/Makefile` — P2P targets: `p2p-build`, `p2p-functional`, `p2p-nft`, `p2p-integration`, `p2p-extended-test`, `p2p-prod`
 - `skeleton/.github/workflows/` — `fast-feedback.yaml`, `extended-test.yaml`, `prod.yaml`
 - `skeleton/p2p/config/` — Helm config per P2P stage (`common.yaml` + per-stage overrides)
@@ -336,6 +336,9 @@ config:
         stabilizationWindowSeconds: 300
   resources:
     limits:
+      cpu: 250m      # use 1000m for JVM-based languages
+      memory: 512Mi  # use 1024Mi for JVM-based languages
+    requests:
       cpu: 250m      # use 1000m for JVM-based languages
       memory: 512Mi  # use 1024Mi for JVM-based languages
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -335,10 +335,10 @@ config:
       scaleDown:
         stabilizationWindowSeconds: 300
   resources:
-    limits:
+    requests:
       cpu: 250m      # use 1000m for JVM-based languages
       memory: 512Mi  # use 1024Mi for JVM-based languages
-    requests:
+    limits:
       cpu: 250m      # use 1000m for JVM-based languages
       memory: 512Mi  # use 1024Mi for JVM-based languages
 ```

--- a/docker/web/skeleton/p2p/config/common.yaml
+++ b/docker/web/skeleton/p2p/config/common.yaml
@@ -14,8 +14,8 @@ autoscaling:
 
 resources:
   requests:
-    cpu: ${p2p_app_config_resources_limits_cpu}
-    memory: ${p2p_app_config_resources_limits_memory}
+    cpu: ${p2p_app_config_resources_requests_cpu}
+    memory: ${p2p_app_config_resources_requests_memory}
   limits:
     cpu: ${p2p_app_config_resources_limits_cpu}
     memory: ${p2p_app_config_resources_limits_memory}

--- a/docker/web/template.yaml
+++ b/docker/web/template.yaml
@@ -19,3 +19,6 @@ config:
     limits:
       cpu: 250m
       memory: 512Mi
+    requests:
+      cpu: 250m
+      memory: 512Mi

--- a/docker/web/template.yaml
+++ b/docker/web/template.yaml
@@ -16,9 +16,9 @@ config:
       scaleDown:
         stabilizationWindowSeconds: 300
   resources:
-    limits:
+    requests:
       cpu: 250m
       memory: 512Mi
-    requests:
+    limits:
       cpu: 250m
       memory: 512Mi

--- a/go/web/skeleton/p2p/config/common.yaml
+++ b/go/web/skeleton/p2p/config/common.yaml
@@ -14,8 +14,8 @@ autoscaling:
 
 resources:
   requests:
-    cpu: ${p2p_app_config_resources_limits_cpu}
-    memory: ${p2p_app_config_resources_limits_memory}
+    cpu: ${p2p_app_config_resources_requests_cpu}
+    memory: ${p2p_app_config_resources_requests_memory}
   limits:
     cpu: ${p2p_app_config_resources_limits_cpu}
     memory: ${p2p_app_config_resources_limits_memory}

--- a/go/web/template.yaml
+++ b/go/web/template.yaml
@@ -19,3 +19,6 @@ config:
     limits:
       cpu: 250m
       memory: 512Mi
+    requests:
+      cpu: 250m
+      memory: 512Mi

--- a/go/web/template.yaml
+++ b/go/web/template.yaml
@@ -16,9 +16,9 @@ config:
       scaleDown:
         stabilizationWindowSeconds: 300
   resources:
-    limits:
+    requests:
       cpu: 250m
       memory: 512Mi
-    requests:
+    limits:
       cpu: 250m
       memory: 512Mi

--- a/java/web/skeleton/p2p/config/common.yaml
+++ b/java/web/skeleton/p2p/config/common.yaml
@@ -14,8 +14,8 @@ autoscaling:
 
 resources:
   requests:
-    cpu: ${p2p_app_config_resources_limits_cpu}
-    memory: ${p2p_app_config_resources_limits_memory}
+    cpu: ${p2p_app_config_resources_requests_cpu}
+    memory: ${p2p_app_config_resources_requests_memory}
   limits:
     cpu: ${p2p_app_config_resources_limits_cpu}
     memory: ${p2p_app_config_resources_limits_memory}

--- a/java/web/template.yaml
+++ b/java/web/template.yaml
@@ -16,9 +16,9 @@ config:
       scaleDown:
         stabilizationWindowSeconds: 300
   resources:
-    limits:
+    requests:
       cpu: 1000m
       memory: 1024Mi
-    requests:
+    limits:
       cpu: 1000m
       memory: 1024Mi

--- a/java/web/template.yaml
+++ b/java/web/template.yaml
@@ -19,3 +19,6 @@ config:
     limits:
       cpu: 1000m
       memory: 1024Mi
+    requests:
+      cpu: 1000m
+      memory: 1024Mi

--- a/nextjs/web/skeleton/p2p/config/common.yaml
+++ b/nextjs/web/skeleton/p2p/config/common.yaml
@@ -14,8 +14,8 @@ autoscaling:
 
 resources:
   requests:
-    cpu: ${p2p_app_config_resources_limits_cpu}
-    memory: ${p2p_app_config_resources_limits_memory}
+    cpu: ${p2p_app_config_resources_requests_cpu}
+    memory: ${p2p_app_config_resources_requests_memory}
   limits:
     cpu: ${p2p_app_config_resources_limits_cpu}
     memory: ${p2p_app_config_resources_limits_memory}

--- a/nextjs/web/template.yaml
+++ b/nextjs/web/template.yaml
@@ -16,9 +16,9 @@ config:
       scaleDown:
         stabilizationWindowSeconds: 300
   resources:
-    limits:
+    requests:
       cpu: 1000m
       memory: 1024Mi
-    requests:
+    limits:
       cpu: 1000m
       memory: 1024Mi

--- a/nextjs/web/template.yaml
+++ b/nextjs/web/template.yaml
@@ -19,3 +19,6 @@ config:
     limits:
       cpu: 1000m
       memory: 1024Mi
+    requests:
+      cpu: 1000m
+      memory: 1024Mi

--- a/python/web/skeleton/p2p/config/common.yaml
+++ b/python/web/skeleton/p2p/config/common.yaml
@@ -14,8 +14,8 @@ autoscaling:
 
 resources:
   requests:
-    cpu: ${p2p_app_config_resources_limits_cpu}
-    memory: ${p2p_app_config_resources_limits_memory}
+    cpu: ${p2p_app_config_resources_requests_cpu}
+    memory: ${p2p_app_config_resources_requests_memory}
   limits:
     cpu: ${p2p_app_config_resources_limits_cpu}
     memory: ${p2p_app_config_resources_limits_memory}

--- a/python/web/template.yaml
+++ b/python/web/template.yaml
@@ -16,9 +16,9 @@ config:
       scaleDown:
         stabilizationWindowSeconds: 300
   resources:
-    limits:
+    requests:
       cpu: 1000m
       memory: 1024Mi
-    requests:
+    limits:
       cpu: 1000m
       memory: 1024Mi

--- a/python/web/template.yaml
+++ b/python/web/template.yaml
@@ -19,3 +19,6 @@ config:
     limits:
       cpu: 1000m
       memory: 1024Mi
+    requests:
+      cpu: 1000m
+      memory: 1024Mi

--- a/schema.yaml
+++ b/schema.yaml
@@ -22,6 +22,9 @@ config:
       scaleDown:
         stabilizationWindowSeconds: int(min=0)
   resources:
+    requests:
+      cpu: str()
+      memory: str()
     limits:
       cpu: str()
       memory: str()

--- a/static/nextra/skeleton/p2p/config/common.yaml
+++ b/static/nextra/skeleton/p2p/config/common.yaml
@@ -14,8 +14,8 @@ autoscaling:
 
 resources:
   requests:
-    cpu: ${p2p_app_config_resources_limits_cpu}
-    memory: ${p2p_app_config_resources_limits_memory}
+    cpu: ${p2p_app_config_resources_requests_cpu}
+    memory: ${p2p_app_config_resources_requests_memory}
   limits:
     cpu: ${p2p_app_config_resources_limits_cpu}
     memory: ${p2p_app_config_resources_limits_memory}

--- a/static/nextra/template.yaml
+++ b/static/nextra/template.yaml
@@ -16,9 +16,9 @@ config:
       scaleDown:
         stabilizationWindowSeconds: 300
   resources:
-    limits:
+    requests:
       cpu: 1000m
       memory: 1024Mi
-    requests:
+    limits:
       cpu: 1000m
       memory: 1024Mi

--- a/static/nextra/template.yaml
+++ b/static/nextra/template.yaml
@@ -19,3 +19,6 @@ config:
     limits:
       cpu: 1000m
       memory: 1024Mi
+    requests:
+      cpu: 1000m
+      memory: 1024Mi


### PR DESCRIPTION
## Summary
- add resources.requests to every app template that defines resources.limits
- update app template schema and authoring guidance for requests
- source P2P Kubernetes resource requests from resources.requests instead of resources.limits

## Verification
- make templates-validate
- searched for P2P request blocks still using resources_limits variables