### PR TITLE
Move app README whitespace trigger

### DIFF
--- a/docker/web/skeleton/README.md
+++ b/docker/web/skeleton/README.md
@@ -1,5 +1,5 @@
 # {{ name }}
-
+ 
 Docker web application for Core Platform
 
 # Parameters
@@ -137,4 +137,3 @@ Extended Test are using [Cucumber Godog](https://github.com/cucumber/godog)
 
 This namespace is used to test that the individual parts of the system as well as service-to-service communication
 of the app works correctly against real dependencies. Currently, using BDD (Behaviour driven development)
-

--- a/go/web/skeleton/README.md
+++ b/go/web/skeleton/README.md
@@ -1,5 +1,5 @@
 # {{ name }}
-
+ 
 Go web application for Core Platform
 
 # Parameters
@@ -204,4 +204,3 @@ betaFeatures:
 When running load tests it is important that we define CPU resource limits. This will allow us to have stable results between runs.
 
 If we don't apply the limits then the performance of the Pods will depend on the CPU utilization of the node that is running the container.
-

--- a/java/web/skeleton/README.md
+++ b/java/web/skeleton/README.md
@@ -1,5 +1,5 @@
 # {{ name }}
-
+ 
 Java web application for Core Platform
 
 # Parameters
@@ -204,4 +204,3 @@ betaFeatures:
 When running load tests it is important that we define CPU resource limits. This will allow us to have stable results between runs.
 
 If we don't apply the limits then the performance of the Pods will depend on the CPU utilization of the node that is running the container.
-

--- a/nextjs/web/skeleton/README.md
+++ b/nextjs/web/skeleton/README.md
@@ -1,5 +1,5 @@
 # {{ name }}
-
+ 
 Next.js web application for Core Platform
 
 # Parameters
@@ -204,4 +204,3 @@ betaFeatures:
 When running load tests it is important that we define CPU resource limits. This will allow us to have stable results between runs.
 
 If we don't apply the limits then the performance of the Pods will depend on the CPU utilization of the node that is running the container.
-

--- a/python/web/skeleton/README.md
+++ b/python/web/skeleton/README.md
@@ -1,5 +1,5 @@
 # {{ name }}
-
+ 
 Python web application for Core Platform
 
 ## Overview
@@ -120,4 +120,3 @@ A Grafana dashboard is available via the internal services domain once the app i
 ### K6 Operator
 
 The NFT and Extended test stages use the K6 Operator on the cluster. The custom K6 build includes the [xk6-prometheus](https://github.com/coreeng/xk6-prometheus) extension so metrics are exported to Prometheus during load tests.
-

--- a/static/nextra/skeleton/README.md
+++ b/static/nextra/skeleton/README.md
@@ -1,5 +1,5 @@
 # {{ name }}
-
+ 
 Nextra docs application for Core Platform
 
 # Parameters
@@ -204,4 +204,3 @@ betaFeatures:
 When running load tests it is important that we define CPU resource limits. This will allow us to have stable results between runs.
 
 If we don't apply the limits then the performance of the Pods will depend on the CPU utilization of the node that is running the container.
-


### PR DESCRIPTION
## Summary
- Remove the final blank line added to each application template README
- Add a single-space line after each README title so rendered template output changes

## Testing
- Verified each README has a single-space line at line 2
- Verified the extra blank final line is removed