### PR TITLE
Skip subnamespace creation for infra templates

### DIFF
--- a/infra/cloudsql/skeleton/.github/workflows/extended-test.yaml
+++ b/infra/cloudsql/skeleton/.github/workflows/extended-test.yaml
@@ -30,6 +30,7 @@ jobs:
       tenant-name: {{ tenant }}
       version: {% raw %}${{ needs.get-latest-version.outputs.version }}{% endraw %}
       version-prefix: {{ version_prefix }}
+      skip-subnamespaces-create: true
 {%- if working_directory is defined and working_directory %}
       working-directory: {{ working_directory }}
 {%- endif %}

--- a/infra/cloudsql/skeleton/.github/workflows/fast-feedback.yaml
+++ b/infra/cloudsql/skeleton/.github/workflows/fast-feedback.yaml
@@ -40,6 +40,7 @@ jobs:
       app-name: {{ name }}
       tenant-name: {{ tenant }}
       version: {% raw %}${{ needs.version.outputs.version }}{% endraw %}
+      skip-subnamespaces-create: true
 {%- if working_directory is defined and working_directory %}
       working-directory: {{ working_directory }}
 {%- endif %}

--- a/infra/cloudsql/skeleton/.github/workflows/prod.yaml
+++ b/infra/cloudsql/skeleton/.github/workflows/prod.yaml
@@ -30,6 +30,7 @@ jobs:
       tenant-name: {{ tenant }}
       version: {% raw %}${{ needs.get-latest-version.outputs.version }}{% endraw %}
       version-prefix: {{ version_prefix }}
+      skip-subnamespaces-create: true
 {%- if working_directory is defined and working_directory %}
       working-directory: {{ working_directory }}
 {%- endif %}

--- a/infra/tofu/skeleton/.github/workflows/extended-test.yaml
+++ b/infra/tofu/skeleton/.github/workflows/extended-test.yaml
@@ -30,6 +30,7 @@ jobs:
       tenant-name: {{ tenant }}
       version: {% raw %}${{ needs.get-latest-version.outputs.version }}{% endraw %}
       version-prefix: {{ version_prefix }}
+      skip-subnamespaces-create: true
 {%- if working_directory is defined and working_directory %}
       working-directory: {{ working_directory }}
 {%- endif %}

--- a/infra/tofu/skeleton/.github/workflows/fast-feedback.yaml
+++ b/infra/tofu/skeleton/.github/workflows/fast-feedback.yaml
@@ -40,6 +40,7 @@ jobs:
       app-name: {{ name }}
       tenant-name: {{ tenant }}
       version: {% raw %}${{ needs.version.outputs.version }}{% endraw %}
+      skip-subnamespaces-create: true
 {%- if working_directory is defined and working_directory %}
       working-directory: {{ working_directory }}
 {%- endif %}

--- a/infra/tofu/skeleton/.github/workflows/prod.yaml
+++ b/infra/tofu/skeleton/.github/workflows/prod.yaml
@@ -30,6 +30,7 @@ jobs:
       tenant-name: {{ tenant }}
       version: {% raw %}${{ needs.get-latest-version.outputs.version }}{% endraw %}
       version-prefix: {{ version_prefix }}
+      skip-subnamespaces-create: true
 {%- if working_directory is defined and working_directory %}
       working-directory: {{ working_directory }}
 {%- endif %}

--- a/infra/urlrouter/skeleton/.github/workflows/extended-test.yaml
+++ b/infra/urlrouter/skeleton/.github/workflows/extended-test.yaml
@@ -30,6 +30,7 @@ jobs:
       tenant-name: {{ tenant }}
       version: {% raw %}${{ needs.get-latest-version.outputs.version }}{% endraw %}
       version-prefix: {{ version_prefix }}
+      skip-subnamespaces-create: true
 {%- if working_directory is defined and working_directory %}
       working-directory: {{ working_directory }}
 {%- endif %}

--- a/infra/urlrouter/skeleton/.github/workflows/fast-feedback.yaml
+++ b/infra/urlrouter/skeleton/.github/workflows/fast-feedback.yaml
@@ -40,6 +40,7 @@ jobs:
       app-name: {{ name }}
       tenant-name: {{ tenant }}
       version: {% raw %}${{ needs.version.outputs.version }}{% endraw %}
+      skip-subnamespaces-create: true
 {%- if working_directory is defined and working_directory %}
       working-directory: {{ working_directory }}
 {%- endif %}

--- a/infra/urlrouter/skeleton/.github/workflows/prod.yaml
+++ b/infra/urlrouter/skeleton/.github/workflows/prod.yaml
@@ -30,6 +30,7 @@ jobs:
       tenant-name: {{ tenant }}
       version: {% raw %}${{ needs.get-latest-version.outputs.version }}{% endraw %}
       version-prefix: {{ version_prefix }}
+      skip-subnamespaces-create: true
 {%- if working_directory is defined and working_directory %}
       working-directory: {{ working_directory }}
 {%- endif %}


### PR DESCRIPTION
## Summary
- Add skip-subnamespaces-create: true to infra fast feedback workflows
- Add skip-subnamespaces-create: true to infra extended test and prod workflows

## Testing
- Ran git diff --check