### PR TITLE
Standardize app template defaults

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -323,11 +323,11 @@ description: <Language> web application
 kind: app
 skeletonPath: ./skeleton
 config:
-  replicas: 2
+  replicas: 3
   autoscaling:
     enabled: true
-    minReplicas: 2
-    maxReplicas: 8
+    minReplicas: 3
+    maxReplicas: 9
     targetCPUUtilizationPercentage: 80
     behavior:
       scaleUp:
@@ -336,7 +336,7 @@ config:
         stabilizationWindowSeconds: 300
   resources:
     requests:
-      cpu: 250m      # use 1000m for JVM-based languages
+      cpu: 50m
       memory: 512Mi  # use 1024Mi for JVM-based languages
     limits:
       cpu: 250m      # use 1000m for JVM-based languages
@@ -394,8 +394,9 @@ publicly. The `/hello` endpoint must return a body containing `"Hello world"` �
 the K6 NFT script asserts.
 
 Use the framework's lightest available Prometheus metrics library. Avoid per-request
-middleware with significant overhead (e.g. full OpenTelemetry tracing instrumentation) —
-the NFT test targets 1000 req/s at 2 replicas × 250m CPU with p(99) < 2000ms.
+middleware with significant overhead (e.g. full OpenTelemetry tracing instrumentation).
+NFT load-test capacity depends on the generated app's resource settings; tune the NFT
+stage or test target per template rather than relying on a fixed CPU-per-replica assumption.
 
 #### 6. Implement functional and integration BDD tests
 

--- a/docker/web/template.yaml
+++ b/docker/web/template.yaml
@@ -4,11 +4,11 @@ description: Docker web application
 kind: app
 skeletonPath: ./skeleton
 config:
-  replicas: 2
+  replicas: 3
   autoscaling:
     enabled: true
-    minReplicas: 2
-    maxReplicas: 8
+    minReplicas: 3
+    maxReplicas: 9
     targetCPUUtilizationPercentage: 80
     behavior:
       scaleUp:
@@ -17,7 +17,7 @@ config:
         stabilizationWindowSeconds: 300
   resources:
     requests:
-      cpu: 250m
+      cpu: 50m
       memory: 512Mi
     limits:
       cpu: 250m

--- a/go/web/template.yaml
+++ b/go/web/template.yaml
@@ -4,11 +4,11 @@ description: Go web application
 kind: app
 skeletonPath: ./skeleton
 config:
-  replicas: 2
+  replicas: 3
   autoscaling:
     enabled: true
-    minReplicas: 2
-    maxReplicas: 8
+    minReplicas: 3
+    maxReplicas: 9
     targetCPUUtilizationPercentage: 80
     behavior:
       scaleUp:
@@ -17,7 +17,7 @@ config:
         stabilizationWindowSeconds: 300
   resources:
     requests:
-      cpu: 250m
+      cpu: 50m
       memory: 512Mi
     limits:
       cpu: 250m

--- a/java/web/template.yaml
+++ b/java/web/template.yaml
@@ -4,11 +4,11 @@ description: Java web application
 kind: app
 skeletonPath: ./skeleton
 config:
-  replicas: 2
+  replicas: 3
   autoscaling:
     enabled: true
-    minReplicas: 2
-    maxReplicas: 8
+    minReplicas: 3
+    maxReplicas: 9
     targetCPUUtilizationPercentage: 80
     behavior:
       scaleUp:
@@ -17,7 +17,7 @@ config:
         stabilizationWindowSeconds: 300
   resources:
     requests:
-      cpu: 1000m
+      cpu: 50m
       memory: 1024Mi
     limits:
       cpu: 1000m

--- a/nextjs/web/template.yaml
+++ b/nextjs/web/template.yaml
@@ -4,11 +4,11 @@ description: Next.js web application
 kind: app
 skeletonPath: ./skeleton
 config:
-  replicas: 2
+  replicas: 3
   autoscaling:
     enabled: true
-    minReplicas: 2
-    maxReplicas: 8
+    minReplicas: 3
+    maxReplicas: 9
     targetCPUUtilizationPercentage: 80
     behavior:
       scaleUp:
@@ -17,7 +17,7 @@ config:
         stabilizationWindowSeconds: 300
   resources:
     requests:
-      cpu: 1000m
+      cpu: 50m
       memory: 1024Mi
     limits:
       cpu: 1000m

--- a/python/web/template.yaml
+++ b/python/web/template.yaml
@@ -4,11 +4,11 @@ description: Python web application
 kind: app
 skeletonPath: ./skeleton
 config:
-  replicas: 2
+  replicas: 3
   autoscaling:
     enabled: true
-    minReplicas: 2
-    maxReplicas: 8
+    minReplicas: 3
+    maxReplicas: 9
     targetCPUUtilizationPercentage: 80
     behavior:
       scaleUp:
@@ -17,7 +17,7 @@ config:
         stabilizationWindowSeconds: 300
   resources:
     requests:
-      cpu: 1000m
+      cpu: 50m
       memory: 1024Mi
     limits:
       cpu: 1000m

--- a/static/nextra/template.yaml
+++ b/static/nextra/template.yaml
@@ -4,11 +4,11 @@ description: Nextra static site application
 kind: app
 skeletonPath: ./skeleton
 config:
-  replicas: 2
+  replicas: 3
   autoscaling:
     enabled: true
-    minReplicas: 2
-    maxReplicas: 8
+    minReplicas: 3
+    maxReplicas: 9
     targetCPUUtilizationPercentage: 80
     behavior:
       scaleUp:
@@ -17,7 +17,7 @@ config:
         stabilizationWindowSeconds: 300
   resources:
     requests:
-      cpu: 1000m
+      cpu: 50m
       memory: 1024Mi
     limits:
       cpu: 1000m


### PR DESCRIPTION
## Summary
- set app template replicas to 3
- set generated HPA bounds to 3-9 with CPU target 80
- lower generated CPU requests to 50m
- leave existing memory requests and limits unchanged
- update app-template authoring guidance and remove stale NFT CPU-per-replica assumption

## Validation
- make templates-validate
- ruby YAML parse for all template.yaml files
- git diff --check
- checked generated defaults summary for all app templates