### PR TITLE
Add Cloud SQL monitoring alert template

### DIFF
--- a/infra/cloudsql/skeleton/infrastructure/code/cloudsql.tf
+++ b/infra/cloudsql/skeleton/infrastructure/code/cloudsql.tf
@@ -3,6 +3,16 @@ variable "cloudsql" {
   type = object({
     enabled           = bool
     allowed_ip_ranges = optional(list(map(string)), [])
+    monitoring = optional(object({
+      notification_emails = optional(list(string), [])
+      thresholds = optional(object({
+        cpu_utilization      = optional(number, 0.9)
+        disk_utilization     = optional(number, 0.8)
+        memory_utilization   = optional(number, 0.9)
+        read_ops_per_second  = optional(number, 1000)
+        write_ops_per_second = optional(number, 1000)
+      }), {})
+    }), {})
     clusters = optional(object({
       postgresql = optional(list(object({
         name               = string

--- a/infra/cloudsql/skeleton/infrastructure/code/modules/cloudsql/README.md
+++ b/infra/cloudsql/skeleton/infrastructure/code/modules/cloudsql/README.md
@@ -44,6 +44,19 @@ The module creates:
 | `enabled` | `bool` | (required) | Whether to create Cloud SQL resources |
 | `allowed_ip_ranges` | `list(map(string))` | `[]` | List of authorized networks for public IP access. Each entry should have `name` and `value` (CIDR) |
 
+#### Monitoring Configuration
+
+The module creates Cloud Monitoring alert policies for each Cloud SQL instance covering CPU utilization, disk utilization, memory utilization, disk read ops, and disk write ops. Email notification channels are created only when `notification_emails` is set.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `monitoring.notification_emails` | `list(string)` | `[]` | Email recipients for Cloud SQL alert notifications. Google Monitoring email channels may require recipient verification before notifications are active. |
+| `monitoring.thresholds.cpu_utilization` | `number` | `0.9` | CPU utilization alert threshold. |
+| `monitoring.thresholds.disk_utilization` | `number` | `0.8` | Disk utilization alert threshold. |
+| `monitoring.thresholds.memory_utilization` | `number` | `0.9` | Memory utilization alert threshold. |
+| `monitoring.thresholds.read_ops_per_second` | `number` | `1000` | Disk read operations per second alert threshold. |
+| `monitoring.thresholds.write_ops_per_second` | `number` | `1000` | Disk write operations per second alert threshold. |
+
 #### Cluster Configuration
 
 Each PostgreSQL cluster supports the following configuration:

--- a/infra/cloudsql/skeleton/infrastructure/code/modules/cloudsql/locals.tf
+++ b/infra/cloudsql/skeleton/infrastructure/code/modules/cloudsql/locals.tf
@@ -41,4 +41,54 @@ locals {
     for member in local.iam_users : member
     if can(regex("^serviceAccount:", member))
   ])
+
+  cloudsql_notification_channels = [
+    for channel in google_monitoring_notification_channel.cloudsql_email : channel.name
+  ]
+
+  cloudsql_alert_metrics = {
+    cpu_utilization = {
+      display_name       = "CPU utilization"
+      metric_type        = "cloudsql.googleapis.com/database/cpu/utilization"
+      threshold          = var.cloudsql.monitoring.thresholds.cpu_utilization
+      alignment_period   = "300s"
+      per_series_aligner = "ALIGN_MEAN"
+    }
+    disk_utilization = {
+      display_name       = "disk utilization"
+      metric_type        = "cloudsql.googleapis.com/database/disk/utilization"
+      threshold          = var.cloudsql.monitoring.thresholds.disk_utilization
+      alignment_period   = "300s"
+      per_series_aligner = "ALIGN_MEAN"
+    }
+    memory_utilization = {
+      display_name       = "memory utilization"
+      metric_type        = "cloudsql.googleapis.com/database/memory/utilization"
+      threshold          = var.cloudsql.monitoring.thresholds.memory_utilization
+      alignment_period   = "300s"
+      per_series_aligner = "ALIGN_MEAN"
+    }
+    read_ops = {
+      display_name       = "disk read ops"
+      metric_type        = "cloudsql.googleapis.com/database/disk/read_ops_count"
+      threshold          = var.cloudsql.monitoring.thresholds.read_ops_per_second
+      alignment_period   = "60s"
+      per_series_aligner = "ALIGN_RATE"
+    }
+    write_ops = {
+      display_name       = "disk write ops"
+      metric_type        = "cloudsql.googleapis.com/database/disk/write_ops_count"
+      threshold          = var.cloudsql.monitoring.thresholds.write_ops_per_second
+      alignment_period   = "60s"
+      per_series_aligner = "ALIGN_RATE"
+    }
+  }
+
+  cloudsql_alert_policies = merge({}, [
+    for cluster_name in keys(local.postgresql_clusters_map) : {
+      for metric_key, metric in local.cloudsql_alert_metrics : "${cluster_name}-${metric_key}" => merge(metric, {
+        instance_name = "${cluster_name}-${var.environment}-cluster"
+      })
+    }
+  ]...)
 }

--- a/infra/cloudsql/skeleton/infrastructure/code/modules/cloudsql/monitoring.tf
+++ b/infra/cloudsql/skeleton/infrastructure/code/modules/cloudsql/monitoring.tf
@@ -1,0 +1,52 @@
+resource "google_project_service" "monitoring" {
+  project                    = var.infrastructure_project_id
+  service                    = "monitoring.googleapis.com"
+  disable_dependent_services = false
+  disable_on_destroy         = false
+}
+
+resource "google_monitoring_notification_channel" "cloudsql_email" {
+  for_each = toset(var.cloudsql.monitoring.notification_emails)
+
+  project      = var.infrastructure_project_id
+  display_name = "Cloud SQL alerts - ${each.value}"
+  type         = "email"
+
+  labels = {
+    email_address = each.value
+  }
+
+  depends_on = [google_project_service.monitoring]
+}
+
+resource "google_monitoring_alert_policy" "cloudsql_metric" {
+  for_each = local.cloudsql_alert_policies
+
+  project               = var.infrastructure_project_id
+  display_name          = "Cloud SQL ${each.value.display_name} - ${each.value.instance_name}"
+  combiner              = "OR"
+  enabled               = true
+  notification_channels = local.cloudsql_notification_channels
+
+  conditions {
+    display_name = "Cloud SQL ${each.value.display_name} above threshold"
+
+    condition_threshold {
+      filter          = "resource.type = \"cloudsql_database\" AND resource.labels.database_id = \"${var.infrastructure_project_id}:${each.value.instance_name}\" AND metric.type = \"${each.value.metric_type}\""
+      comparison      = "COMPARISON_GT"
+      duration        = "300s"
+      threshold_value = each.value.threshold
+
+      aggregations {
+        alignment_period   = each.value.alignment_period
+        per_series_aligner = each.value.per_series_aligner
+      }
+
+      trigger {
+        count = 1
+      }
+    }
+  }
+
+  depends_on = [google_project_service.monitoring]
+}

--- a/infra/cloudsql/skeleton/infrastructure/code/modules/cloudsql/variables.tf
+++ b/infra/cloudsql/skeleton/infrastructure/code/modules/cloudsql/variables.tf
@@ -19,6 +19,16 @@ variable "cloudsql" {
   type = object({
     enabled           = bool
     allowed_ip_ranges = optional(list(map(string)), [])
+    monitoring = optional(object({
+      notification_emails = optional(list(string), [])
+      thresholds = optional(object({
+        cpu_utilization      = optional(number, 0.9)
+        disk_utilization     = optional(number, 0.8)
+        memory_utilization   = optional(number, 0.9)
+        read_ops_per_second  = optional(number, 1000)
+        write_ops_per_second = optional(number, 1000)
+      }), {})
+    }), {})
     clusters = optional(object({
       postgresql = optional(list(object({
         name               = string


### PR DESCRIPTION
## Summary
- add Cloud SQL monitoring config to the infra/cloudsql template with zero-to-many email recipients and configurable thresholds
- provision Cloud Monitoring alert policies for CPU utilization, disk utilization, memory utilization, disk read ops, and disk write ops
- enable the Monitoring API through a standalone google_project_service used only by monitoring resources to avoid forcing Cloud SQL PSA replacement
- document monitoring inputs in the Cloud SQL module README

## Threshold Defaults
- cpu_utilization: 0.9
- disk_utilization: 0.8
- memory_utilization: 0.9
- read_ops_per_second: 1000
- write_ops_per_second: 1000

## Verification
- tofu fmt -recursive
- tofu init -backend=false
- tofu validate
- tofu fmt -check -recursive
- git diff --check