### PR TITLE
Add Cloud SQL IDS compliance resources

### DIFF
--- a/infra/cloudsql/skeleton/infrastructure/code/cloudsql.tf
+++ b/infra/cloudsql/skeleton/infrastructure/code/cloudsql.tf
@@ -13,6 +13,13 @@ variable "cloudsql" {
         write_ops_per_second = optional(number, 1000)
       }), {})
     }), {})
+    ids = optional(object({
+      enabled               = optional(bool, false)
+      location              = optional(string)
+      severity              = optional(string, "INFORMATIONAL")
+      packet_mirroring_tags = optional(list(string), ["cloudsql-psa"])
+      notifications_enabled = optional(bool, true)
+    }), {})
     clusters = optional(object({
       postgresql = optional(list(object({
         name               = string
@@ -78,6 +85,11 @@ variable "cloudsql" {
       })))
     }))
   })
+
+  validation {
+    condition     = contains(["INFORMATIONAL", "LOW", "MEDIUM"], try(var.cloudsql.ids.severity, "INFORMATIONAL"))
+    error_message = "cloudsql.ids.severity must be INFORMATIONAL, LOW, or MEDIUM."
+  }
 }
 
 module "cloudsql" {

--- a/infra/cloudsql/skeleton/infrastructure/code/modules/cloudsql/cloud_ids.tf
+++ b/infra/cloudsql/skeleton/infrastructure/code/modules/cloudsql/cloud_ids.tf
@@ -1,0 +1,106 @@
+resource "google_project_service" "cloud_ids" {
+  count = local.cloud_ids_enabled ? 1 : 0
+
+  project                    = var.infrastructure_project_id
+  service                    = "ids.googleapis.com"
+  disable_dependent_services = false
+  disable_on_destroy         = false
+}
+
+resource "google_project_service" "logging" {
+  count = local.cloud_ids_enabled && local.cloud_ids_notifications_enabled ? 1 : 0
+
+  project                    = var.infrastructure_project_id
+  service                    = "logging.googleapis.com"
+  disable_dependent_services = false
+  disable_on_destroy         = false
+}
+
+resource "google_cloud_ids_endpoint" "psa" {
+  count = local.cloud_ids_enabled ? 1 : 0
+
+  project  = var.infrastructure_project_id
+  name     = "cloudsql-${var.environment}-ids"
+  location = local.cloud_ids_location
+  network  = google_compute_network.psa.id
+  severity = local.cloud_ids_severity
+
+  depends_on = [google_project_service.cloud_ids, module.cloudsql-psa]
+}
+
+resource "google_compute_packet_mirroring" "psa" {
+  count = local.cloud_ids_enabled ? 1 : 0
+
+  project = var.infrastructure_project_id
+  region  = var.region
+  name    = "cloudsql-${var.environment}-ids-mirroring"
+
+  network {
+    url = google_compute_network.psa.id
+  }
+
+  collector_ilb {
+    url = google_cloud_ids_endpoint.psa[0].endpoint_forwarding_rule
+  }
+
+  mirrored_resources {
+    tags = local.cloud_ids_packet_mirroring_tags
+  }
+
+  filter {
+    direction   = "BOTH"
+    cidr_ranges = ["0.0.0.0/0"]
+  }
+}
+
+resource "google_logging_metric" "cloud_ids_threat_detections" {
+  count = local.cloud_ids_enabled && local.cloud_ids_notifications_enabled ? 1 : 0
+
+  project = var.infrastructure_project_id
+  name    = "cloud_ids_${var.environment}_threat_detections"
+  filter  = "resource.type=\"ids.googleapis.com/Endpoint\""
+
+  metric_descriptor {
+    metric_kind = "DELTA"
+    value_type  = "INT64"
+    unit        = "1"
+  }
+
+  depends_on = [google_project_service.logging]
+}
+
+resource "google_monitoring_alert_policy" "cloud_ids_threat_detections" {
+  count = local.cloud_ids_enabled && local.cloud_ids_notifications_enabled && length(var.cloudsql.monitoring.notification_emails) > 0 ? 1 : 0
+
+  project               = var.infrastructure_project_id
+  display_name          = "Cloud IDS threat detections - cloudsql-${var.environment}-psa"
+  combiner              = "OR"
+  enabled               = true
+  notification_channels = local.cloudsql_notification_channels
+
+  conditions {
+    display_name = "Cloud IDS endpoint threat detection logs"
+
+    condition_threshold {
+      filter          = "resource.type=\"ids.googleapis.com/Endpoint\" AND metric.type=\"logging.googleapis.com/user/${google_logging_metric.cloud_ids_threat_detections[0].name}\""
+      comparison      = "COMPARISON_GT"
+      duration        = "0s"
+      threshold_value = 0
+
+      aggregations {
+        alignment_period     = "60s"
+        per_series_aligner   = "ALIGN_DELTA"
+        cross_series_reducer = "REDUCE_SUM"
+      }
+
+      trigger {
+        count = 1
+      }
+    }
+  }
+
+  depends_on = [
+    google_project_service.monitoring,
+    google_logging_metric.cloud_ids_threat_detections,
+  ]
+}

--- a/infra/cloudsql/skeleton/infrastructure/code/modules/cloudsql/locals.tf
+++ b/infra/cloudsql/skeleton/infrastructure/code/modules/cloudsql/locals.tf
@@ -46,6 +46,12 @@ locals {
     for channel in google_monitoring_notification_channel.cloudsql_email : channel.name
   ]
 
+  cloud_ids_enabled               = try(var.cloudsql.ids.enabled, false)
+  cloud_ids_location              = coalesce(try(var.cloudsql.ids.location, null), "${var.region}-b")
+  cloud_ids_severity              = try(var.cloudsql.ids.severity, "INFORMATIONAL")
+  cloud_ids_packet_mirroring_tags = try(var.cloudsql.ids.packet_mirroring_tags, ["cloudsql-psa"])
+  cloud_ids_notifications_enabled = try(var.cloudsql.ids.notifications_enabled, true)
+
   cloudsql_alert_metrics = {
     cpu_utilization = {
       display_name       = "CPU utilization"

--- a/infra/cloudsql/skeleton/infrastructure/code/modules/cloudsql/variables.tf
+++ b/infra/cloudsql/skeleton/infrastructure/code/modules/cloudsql/variables.tf
@@ -29,6 +29,13 @@ variable "cloudsql" {
         write_ops_per_second = optional(number, 1000)
       }), {})
     }), {})
+    ids = optional(object({
+      enabled               = optional(bool, false)
+      location              = optional(string)
+      severity              = optional(string, "INFORMATIONAL")
+      packet_mirroring_tags = optional(list(string), ["cloudsql-psa"])
+      notifications_enabled = optional(bool, true)
+    }), {})
     clusters = optional(object({
       postgresql = optional(list(object({
         name               = string
@@ -94,4 +101,9 @@ variable "cloudsql" {
       })))
     }))
   })
+
+  validation {
+    condition     = contains(["INFORMATIONAL", "LOW", "MEDIUM"], try(var.cloudsql.ids.severity, "INFORMATIONAL"))
+    error_message = "cloudsql.ids.severity must be INFORMATIONAL, LOW, or MEDIUM."
+  }
 }


### PR DESCRIPTION
## Summary

- Add optional Cloud IDS resources for Cloud SQL PSA VPCs.
- Keep Cloud IDS disabled by default because each endpoint costs about `$1.1k/month` before inspected traffic charges.
- Enable IDS and Logging APIs with standalone `google_project_service` resources to avoid PSA replacement.
- Add packet mirroring, a logs-based threat detection metric, and a notification-backed alert policy when explicitly enabled.

## Validation

- `tofu fmt -recursive`
- `tofu init -backend=false -input=false`
- `tofu validate`

## Enabling

```yaml
cloudsql:
  ids:
    enabled: true
```
