### PR TITLE
Remove unused Playwright imports

### DIFF
--- a/nextjs/web/skeleton/p2p/tests/functional/tests/steps/home.step.ts
+++ b/nextjs/web/skeleton/p2p/tests/functional/tests/steps/home.step.ts
@@ -1,5 +1,5 @@
 import { Then, Given } from "@cucumber/cucumber";
-import { expect, Locator } from "@playwright/test";
+import { expect } from "@playwright/test";
 import { CustomWorld } from "./custom-world";
 
 const BASE_URL = process.env.SERVICE_ENDPOINT || "http://localhost:3000";

--- a/static/nextra/skeleton/p2p/tests/functional/tests/steps/home.step.ts
+++ b/static/nextra/skeleton/p2p/tests/functional/tests/steps/home.step.ts
@@ -1,5 +1,5 @@
 import { Then, Given } from "@cucumber/cucumber";
-import { expect, Locator } from "@playwright/test";
+import { expect } from "@playwright/test";
 import { CustomWorld } from "./custom-world";
 
 const BASE_URL = process.env.SERVICE_ENDPOINT || "http://localhost:3000";


### PR DESCRIPTION
## Summary
- remove unused Locator imports from Next.js and Nextra functional test steps

## Verification
- nextjs functional tests: yarn install --frozen-lockfile --ignore-engines, yarn tsc --noEmit --ignoreDeprecations 6.0 in a substituted throwaway copy
- static/nextra functional tests: yarn install --frozen-lockfile --ignore-engines, yarn tsc --noEmit --ignoreDeprecations 6.0 in a substituted throwaway copy
- git diff --check

Note: plain yarn tsc --noEmit currently fails on the existing TypeScript 6 moduleResolution=node10 deprecation, so verification used the TypeScript-recommended --ignoreDeprecations 6.0 flag without changing template config.