### PR TITLE
Limit workflow token permissions

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -10,10 +10,13 @@ on:
 jobs:
   validate:
     name: Validate
+    permissions:
+      contents: read
     uses: ./.github/workflows/validate.yaml
 
   trigger-rendering:
     name: Trigger Rendering
+    permissions: {}
     runs-on: ubuntu-24.04
     steps:
       - name: Trigger Rendering

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,4 +9,6 @@ on:
 jobs:
   validate:
     name: Validate
+    permissions:
+      contents: read
     uses: ./.github/workflows/validate.yaml

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -3,6 +3,9 @@ name: Validate
 
 on: workflow_call
 
+permissions:
+  contents: read
+
 jobs:
   templates:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Summary
- add explicit contents: read permissions for validation workflows that use checkout
- add explicit empty permissions for the PAT-driven rendering dispatch job
- address CodeQL workflow permission warnings in cd.yaml, ci.yaml, and validate.yaml

## Verification
- git diff --check
- actionlint .github/workflows/cd.yaml .github/workflows/ci.yaml .github/workflows/validate.yaml