### PR TITLE
Escape Java greeting name

### DIFF
--- a/java/web/skeleton/service/src/main/java/io/cecg/referenceapplication/api/controllers/GreetingController.java
+++ b/java/web/skeleton/service/src/main/java/io/cecg/referenceapplication/api/controllers/GreetingController.java
@@ -3,11 +3,12 @@ package io.cecg.referenceapplication.api.controllers;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.HtmlUtils;
 
 @RestController
 public class GreetingController {
     @GetMapping("/hello")
     public String hello(@RequestParam(value = "name", defaultValue = "World") String name) {
-        return String.format("Hello %s!", name);
+        return String.format("Hello %s!", HtmlUtils.htmlEscape(name));
     }
 }

--- a/java/web/skeleton/service/src/test/java/io/cecg/referenceapplication/api/controllers/GreetingControllerTest.java
+++ b/java/web/skeleton/service/src/test/java/io/cecg/referenceapplication/api/controllers/GreetingControllerTest.java
@@ -1,0 +1,17 @@
+package io.cecg.referenceapplication.api.controllers;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class GreetingControllerTest {
+    private final GreetingController controller = new GreetingController();
+
+    @Test
+    void escapesNameParameter() {
+        assertEquals(
+                "Hello &lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;!",
+                controller.hello("<script>alert(\"xss\")</script>")
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- HTML-escape the user-provided /hello name query parameter before reflecting it in the response
- add a controller regression test for script-tag input escaping
- address CodeQL CWE-79 finding in GreetingController.java

## Verification
- ./gradlew test from java/web/skeleton
- git diff --check