### PR TITLE
Expand Java greeting controller tests

### DIFF
--- a/java/web/skeleton/service/src/main/java/io/cecg/referenceapplication/api/controllers/GreetingController.java
+++ b/java/web/skeleton/service/src/main/java/io/cecg/referenceapplication/api/controllers/GreetingController.java
@@ -9,6 +9,6 @@ import org.springframework.web.util.HtmlUtils;
 public class GreetingController {
     @GetMapping("/hello")
     public String hello(@RequestParam(value = "name", defaultValue = "World") String name) {
-        return String.format("Hello %s!", HtmlUtils.htmlEscape(name));
+        return String.format("Hello %s!", name == null ? "" : HtmlUtils.htmlEscape(name));
     }
 }

--- a/java/web/skeleton/service/src/test/java/io/cecg/referenceapplication/api/controllers/GreetingControllerTest.java
+++ b/java/web/skeleton/service/src/test/java/io/cecg/referenceapplication/api/controllers/GreetingControllerTest.java
@@ -8,6 +8,21 @@ class GreetingControllerTest {
     private final GreetingController controller = new GreetingController();
 
     @Test
+    void returnsGreetingForNormalName() {
+        assertEquals("Hello John!", controller.hello("John"));
+    }
+
+    @Test
+    void handlesEmptyName() {
+        assertEquals("Hello !", controller.hello(""));
+    }
+
+    @Test
+    void handlesNullName() {
+        assertEquals("Hello !", controller.hello(null));
+    }
+
+    @Test
     void escapesNameParameter() {
         assertEquals(
                 "Hello &lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;!",


### PR DESCRIPTION
## Summary
- add controller tests for normal, empty, and null name inputs
- make the greeting controller tolerate direct null input by treating it as an empty name
- keep existing XSS escaping regression coverage

## Verification
- ./gradlew test from java/web/skeleton
- git diff --check