### PR TITLE
Add scheduled security scan workflows to templates

### DIFF
--- a/docker/web/skeleton/.github/workflows/fast-feedback.yaml
+++ b/docker/web/skeleton/.github/workflows/fast-feedback.yaml
@@ -21,6 +21,7 @@ on:
 permissions:
   contents: write
   id-token: write
+  pull-requests: write
 
 jobs:
   version:

--- a/docker/web/skeleton/.github/workflows/scheduled-security-scan.yaml
+++ b/docker/web/skeleton/.github/workflows/scheduled-security-scan.yaml
@@ -1,0 +1,23 @@
+---
+name: {{ name }} Security Scan
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 4 * * *"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  scheduled-security-scan:
+    uses: coreeng/p2p/.github/workflows/p2p-workflow-security-scan.yaml@v1
+    secrets:
+      env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
+    with:
+      tenant-name: {{ tenant }}
+      security-scan-blocking-severity: "off"
+{%- if working_directory is defined and working_directory %}
+      working-directory: {{ working_directory }}
+{%- endif %}

--- a/go/web/skeleton/.github/workflows/fast-feedback.yaml
+++ b/go/web/skeleton/.github/workflows/fast-feedback.yaml
@@ -21,6 +21,7 @@ on:
 permissions:
   contents: write
   id-token: write
+  pull-requests: write
 
 jobs:
   version:

--- a/go/web/skeleton/.github/workflows/scheduled-security-scan.yaml
+++ b/go/web/skeleton/.github/workflows/scheduled-security-scan.yaml
@@ -1,0 +1,23 @@
+---
+name: {{ name }} Security Scan
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 4 * * *"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  scheduled-security-scan:
+    uses: coreeng/p2p/.github/workflows/p2p-workflow-security-scan.yaml@v1
+    secrets:
+      env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
+    with:
+      tenant-name: {{ tenant }}
+      security-scan-blocking-severity: "off"
+{%- if working_directory is defined and working_directory %}
+      working-directory: {{ working_directory }}
+{%- endif %}

--- a/infra/cloudsql/skeleton/.github/workflows/fast-feedback.yaml
+++ b/infra/cloudsql/skeleton/.github/workflows/fast-feedback.yaml
@@ -21,6 +21,7 @@ on:
 permissions:
   contents: write
   id-token: write
+  pull-requests: write
 
 jobs:
   version:

--- a/infra/cloudsql/skeleton/.github/workflows/scheduled-security-scan.yaml
+++ b/infra/cloudsql/skeleton/.github/workflows/scheduled-security-scan.yaml
@@ -1,0 +1,23 @@
+---
+name: {{ name }} Security Scan
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 4 * * *"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  scheduled-security-scan:
+    uses: coreeng/p2p/.github/workflows/p2p-workflow-security-scan.yaml@v1
+    secrets:
+      env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
+    with:
+      tenant-name: {{ tenant }}
+      security-scan-blocking-severity: "off"
+{%- if working_directory is defined and working_directory %}
+      working-directory: {{ working_directory }}
+{%- endif %}

--- a/infra/tofu/skeleton/.github/workflows/fast-feedback.yaml
+++ b/infra/tofu/skeleton/.github/workflows/fast-feedback.yaml
@@ -21,6 +21,7 @@ on:
 permissions:
   contents: write
   id-token: write
+  pull-requests: write
 
 jobs:
   version:

--- a/infra/tofu/skeleton/.github/workflows/scheduled-security-scan.yaml
+++ b/infra/tofu/skeleton/.github/workflows/scheduled-security-scan.yaml
@@ -1,0 +1,23 @@
+---
+name: {{ name }} Security Scan
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 4 * * *"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  scheduled-security-scan:
+    uses: coreeng/p2p/.github/workflows/p2p-workflow-security-scan.yaml@v1
+    secrets:
+      env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
+    with:
+      tenant-name: {{ tenant }}
+      security-scan-blocking-severity: "off"
+{%- if working_directory is defined and working_directory %}
+      working-directory: {{ working_directory }}
+{%- endif %}

--- a/infra/urlrouter/skeleton/.github/workflows/fast-feedback.yaml
+++ b/infra/urlrouter/skeleton/.github/workflows/fast-feedback.yaml
@@ -21,6 +21,7 @@ on:
 permissions:
   contents: write
   id-token: write
+  pull-requests: write
 
 jobs:
   version:

--- a/infra/urlrouter/skeleton/.github/workflows/scheduled-security-scan.yaml
+++ b/infra/urlrouter/skeleton/.github/workflows/scheduled-security-scan.yaml
@@ -1,0 +1,23 @@
+---
+name: {{ name }} Security Scan
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 4 * * *"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  scheduled-security-scan:
+    uses: coreeng/p2p/.github/workflows/p2p-workflow-security-scan.yaml@v1
+    secrets:
+      env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
+    with:
+      tenant-name: {{ tenant }}
+      security-scan-blocking-severity: "off"
+{%- if working_directory is defined and working_directory %}
+      working-directory: {{ working_directory }}
+{%- endif %}

--- a/java/web/skeleton/.github/workflows/fast-feedback.yaml
+++ b/java/web/skeleton/.github/workflows/fast-feedback.yaml
@@ -21,6 +21,7 @@ on:
 permissions:
   contents: write
   id-token: write
+  pull-requests: write
 
 jobs:
   version:

--- a/java/web/skeleton/.github/workflows/scheduled-security-scan.yaml
+++ b/java/web/skeleton/.github/workflows/scheduled-security-scan.yaml
@@ -1,0 +1,23 @@
+---
+name: {{ name }} Security Scan
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 4 * * *"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  scheduled-security-scan:
+    uses: coreeng/p2p/.github/workflows/p2p-workflow-security-scan.yaml@v1
+    secrets:
+      env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
+    with:
+      tenant-name: {{ tenant }}
+      security-scan-blocking-severity: "off"
+{%- if working_directory is defined and working_directory %}
+      working-directory: {{ working_directory }}
+{%- endif %}

--- a/nextjs/web/skeleton/.github/workflows/fast-feedback.yaml
+++ b/nextjs/web/skeleton/.github/workflows/fast-feedback.yaml
@@ -21,6 +21,7 @@ on:
 permissions:
   contents: write
   id-token: write
+  pull-requests: write
 
 jobs:
   version:

--- a/nextjs/web/skeleton/.github/workflows/scheduled-security-scan.yaml
+++ b/nextjs/web/skeleton/.github/workflows/scheduled-security-scan.yaml
@@ -1,0 +1,23 @@
+---
+name: {{ name }} Security Scan
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 4 * * *"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  scheduled-security-scan:
+    uses: coreeng/p2p/.github/workflows/p2p-workflow-security-scan.yaml@v1
+    secrets:
+      env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
+    with:
+      tenant-name: {{ tenant }}
+      security-scan-blocking-severity: "off"
+{%- if working_directory is defined and working_directory %}
+      working-directory: {{ working_directory }}
+{%- endif %}

--- a/python/web/skeleton/.github/workflows/fast-feedback.yaml
+++ b/python/web/skeleton/.github/workflows/fast-feedback.yaml
@@ -21,6 +21,7 @@ on:
 permissions:
   contents: write
   id-token: write
+  pull-requests: write
 
 jobs:
   version:

--- a/python/web/skeleton/.github/workflows/scheduled-security-scan.yaml
+++ b/python/web/skeleton/.github/workflows/scheduled-security-scan.yaml
@@ -1,0 +1,23 @@
+---
+name: {{ name }} Security Scan
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 4 * * *"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  scheduled-security-scan:
+    uses: coreeng/p2p/.github/workflows/p2p-workflow-security-scan.yaml@v1
+    secrets:
+      env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
+    with:
+      tenant-name: {{ tenant }}
+      security-scan-blocking-severity: "off"
+{%- if working_directory is defined and working_directory %}
+      working-directory: {{ working_directory }}
+{%- endif %}

--- a/static/nextra/skeleton/.github/workflows/fast-feedback.yaml
+++ b/static/nextra/skeleton/.github/workflows/fast-feedback.yaml
@@ -21,6 +21,7 @@ on:
 permissions:
   contents: write
   id-token: write
+  pull-requests: write
 
 jobs:
   version:

--- a/static/nextra/skeleton/.github/workflows/scheduled-security-scan.yaml
+++ b/static/nextra/skeleton/.github/workflows/scheduled-security-scan.yaml
@@ -1,0 +1,23 @@
+---
+name: {{ name }} Security Scan
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 4 * * *"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  scheduled-security-scan:
+    uses: coreeng/p2p/.github/workflows/p2p-workflow-security-scan.yaml@v1
+    secrets:
+      env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
+    with:
+      tenant-name: {{ tenant }}
+      security-scan-blocking-severity: "off"
+{%- if working_directory is defined and working_directory %}
+      working-directory: {{ working_directory }}
+{%- endif %}


### PR DESCRIPTION
## Summary
- add scheduled P2P security scan workflows to all app and infra skeletons
- grant fast-feedback pull request write permission so security scans can post PR comments
- use the template-style env_vars forwarding for scheduled scanning

## Templates updated
- go/web
- java/web
- python/web
- docker/web
- nextjs/web
- static/nextra
- infra/cloudsql
- infra/tofu
- infra/urlrouter

## Validation
- make templates-validate
- rendered all changed fast-feedback and scheduled-security-scan workflow templates with sample values and ran actionlint