### PR TITLE
Remove extra README blank lines

### DIFF
--- a/docker/web/skeleton/README.md
+++ b/docker/web/skeleton/README.md
@@ -1,6 +1,5 @@
 # {{ name }}
 
-
 Docker web application for Core Platform
 
 # Parameters

--- a/go/web/skeleton/README.md
+++ b/go/web/skeleton/README.md
@@ -1,6 +1,5 @@
 # {{ name }}
 
-
 Go web application for Core Platform
 
 # Parameters

--- a/java/web/skeleton/README.md
+++ b/java/web/skeleton/README.md
@@ -1,6 +1,5 @@
 # {{ name }}
 
-
 Java web application for Core Platform
 
 # Parameters

--- a/nextjs/web/skeleton/README.md
+++ b/nextjs/web/skeleton/README.md
@@ -1,6 +1,5 @@
 # {{ name }}
 
-
 Next.js web application for Core Platform
 
 # Parameters

--- a/python/web/skeleton/README.md
+++ b/python/web/skeleton/README.md
@@ -1,6 +1,5 @@
 # {{ name }}
 
-
 Python web application for Core Platform
 
 ## Overview

--- a/static/nextra/skeleton/README.md
+++ b/static/nextra/skeleton/README.md
@@ -1,6 +1,5 @@
 # {{ name }}
 
-
 Nextra docs application for Core Platform
 
 # Parameters


### PR DESCRIPTION
## Summary
- remove the extra blank line after the first heading in app template README files

## Testing
- not run; docs-only formatting change