### PR TITLE
Update template Alpine images

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,6 +171,13 @@ yarn install
 
 Keep `yarn.lock` committed; the template Dockerfiles use `yarn --frozen-lockfile`.
 
+> **Known Nextra issue:** Do not upgrade `static/nextra` from `nextra`/`nextra-theme-docs`
+> `4.6.0` to `4.6.1` unless the upstream issue is fixed or you have a template code fix.
+> The upgrade has been tested and causes `next build` to fail while prerendering
+> `/_not-found` with digest `1872370934`, including when adding an explicit plain
+> `src/app/not-found.tsx`. Keep `static/nextra` on `4.6.0` until a smoke test proves a
+> newer version builds successfully.
+
 For `nextjs/web` and `static/nextra` — also update `p2p/tests/functional/package.json` (no
 `{{ name }}` substitution needed; for `static/nextra`, temporarily set parent `package.json`
 `name` to a valid value so `yarn install` can run):

--- a/docker/web/skeleton/p2p/tests/nft/Dockerfile
+++ b/docker/web/skeleton/p2p/tests/nft/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/golang:1.26.4-alpine3.23 AS build
+FROM docker.io/golang:1.26.4-alpine3.24 AS build
 WORKDIR $GOPATH/src/go.k6.io/k6
 
 # hadolint ignore=DL3018
@@ -8,7 +8,7 @@ RUN apk add --no-cache git && \
 
 FROM docker.io/prom/prometheus:v2.55.1 AS prometheus
 
-FROM docker.io/alpine:3.23.4
+FROM docker.io/alpine:3.24.1
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache ca-certificates && \

--- a/go/web/skeleton/Dockerfile
+++ b/go/web/skeleton/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/golang:1.26.4-alpine3.23 AS build
+FROM docker.io/golang:1.26.4-alpine3.24 AS build
 WORKDIR /app
 COPY ./cmd /app/cmd
 COPY go.mod /app

--- a/go/web/skeleton/p2p/tests/extended/Dockerfile
+++ b/go/web/skeleton/p2p/tests/extended/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/alpine:3.23.4
+FROM docker.io/alpine:3.24.1
 
 ENTRYPOINT ["echo"]
 CMD ["### extended tests not implemented ###"]

--- a/go/web/skeleton/p2p/tests/functional/Dockerfile
+++ b/go/web/skeleton/p2p/tests/functional/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/golang:1.26.4-alpine3.23 AS build
+FROM docker.io/golang:1.26.4-alpine3.24 AS build
 
 # hadolint ignore=DL3018
 RUN apk --no-cache add build-base && \

--- a/go/web/skeleton/p2p/tests/integration/Dockerfile
+++ b/go/web/skeleton/p2p/tests/integration/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/golang:1.26.4-alpine3.23 AS build
+FROM docker.io/golang:1.26.4-alpine3.24 AS build
 
 # hadolint ignore=DL3018
 RUN apk --no-cache add build-base && \

--- a/go/web/skeleton/p2p/tests/nft/Dockerfile
+++ b/go/web/skeleton/p2p/tests/nft/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/golang:1.26.4-alpine3.23 AS build
+FROM docker.io/golang:1.26.4-alpine3.24 AS build
 WORKDIR $GOPATH/src/go.k6.io/k6
 
 # hadolint ignore=DL3018
@@ -8,7 +8,7 @@ RUN apk add --no-cache git && \
 
 FROM docker.io/prom/prometheus:v2.55.1 AS prometheus
 
-FROM docker.io/alpine:3.23.4
+FROM docker.io/alpine:3.24.1
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache ca-certificates && \

--- a/java/web/skeleton/p2p/tests/extended/Dockerfile
+++ b/java/web/skeleton/p2p/tests/extended/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/alpine:3.23.4
+FROM docker.io/alpine:3.24.1
 
 ENTRYPOINT ["echo"]
 CMD ["### extended tests not implemented ###"]

--- a/java/web/skeleton/p2p/tests/nft/Dockerfile
+++ b/java/web/skeleton/p2p/tests/nft/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/golang:1.26.4-alpine3.23 AS build
+FROM docker.io/golang:1.26.4-alpine3.24 AS build
 WORKDIR $GOPATH/src/go.k6.io/k6
 
 # hadolint ignore=DL3018
@@ -8,7 +8,7 @@ RUN apk add --no-cache git && \
 
 FROM docker.io/prom/prometheus:v2.55.1 AS prometheus
 
-FROM docker.io/alpine:3.23.4
+FROM docker.io/alpine:3.24.1
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache ca-certificates && \

--- a/nextjs/web/skeleton/p2p/tests/extended/Dockerfile
+++ b/nextjs/web/skeleton/p2p/tests/extended/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/alpine:3.23.4
+FROM docker.io/alpine:3.24.1
 
 ENTRYPOINT ["echo"]
 CMD ["### extended tests not implemented ###"]

--- a/nextjs/web/skeleton/p2p/tests/integration/Dockerfile
+++ b/nextjs/web/skeleton/p2p/tests/integration/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/alpine:3.23.4
+FROM docker.io/alpine:3.24.1
 
 ENTRYPOINT ["echo"]
 CMD ["### integration tests not implemented ###"]

--- a/nextjs/web/skeleton/p2p/tests/nft/Dockerfile
+++ b/nextjs/web/skeleton/p2p/tests/nft/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/golang:1.26.4-alpine3.23 AS build
+FROM docker.io/golang:1.26.4-alpine3.24 AS build
 WORKDIR $GOPATH/src/go.k6.io/k6
 
 # hadolint ignore=DL3018
@@ -8,7 +8,7 @@ RUN apk add --no-cache git && \
 
 FROM docker.io/prom/prometheus:v2.55.1 AS prometheus
 
-FROM docker.io/alpine:3.23.4
+FROM docker.io/alpine:3.24.1
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache ca-certificates && \

--- a/python/web/skeleton/p2p/tests/nft/Dockerfile
+++ b/python/web/skeleton/p2p/tests/nft/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/golang:1.26.4-alpine3.23 AS build
+FROM docker.io/golang:1.26.4-alpine3.24 AS build
 WORKDIR $GOPATH/src/go.k6.io/k6
 
 # hadolint ignore=DL3018
@@ -8,7 +8,7 @@ RUN apk add --no-cache git && \
 
 FROM docker.io/prom/prometheus:v2.55.1 AS prometheus
 
-FROM docker.io/alpine:3.23.4
+FROM docker.io/alpine:3.24.1
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache ca-certificates && \

--- a/static/nextra/skeleton/p2p/tests/extended/Dockerfile
+++ b/static/nextra/skeleton/p2p/tests/extended/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/alpine:3.23.4
+FROM docker.io/alpine:3.24.1
 
 ENTRYPOINT ["echo"]
 CMD ["### extended tests not implemented ###"]

--- a/static/nextra/skeleton/p2p/tests/integration/Dockerfile
+++ b/static/nextra/skeleton/p2p/tests/integration/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/alpine:3.23.4
+FROM docker.io/alpine:3.24.1
 
 ENTRYPOINT ["echo"]
 CMD ["### integration tests not implemented ###"]

--- a/static/nextra/skeleton/p2p/tests/nft/Dockerfile
+++ b/static/nextra/skeleton/p2p/tests/nft/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/golang:1.26.4-alpine3.23 AS build
+FROM docker.io/golang:1.26.4-alpine3.24 AS build
 WORKDIR $GOPATH/src/go.k6.io/k6
 
 # hadolint ignore=DL3018
@@ -8,7 +8,7 @@ RUN apk add --no-cache git && \
 
 FROM docker.io/prom/prometheus:v2.55.1 AS prometheus
 
-FROM docker.io/alpine:3.23.4
+FROM docker.io/alpine:3.24.1
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache ca-certificates && \


### PR DESCRIPTION
## Summary
- update Go-based template builder images to golang:1.26.4-alpine3.24
- update NFT and placeholder Alpine runtimes to alpine:3.24.1 across app templates
- verified other dependency pins with ecosystem resolvers/registries; no net package updates were buildable

## Verification
- stale pin scan for alpine3.23/alpine:3.23.4
- application Docker smoke tests for go/web, python/web, java/web, nextjs/web, static/nextra, docker/web
- built all P2P test container Dockerfiles across changed templates

## Notes
- Gradle 9.6.0 is released, but docker.io/gradle:9.6.0-jdk25-noble is not available, so Java stayed on 9.5.1 to keep wrapper/image parity.
- Nextra 4.6.1 was tested but failed static/nextra next build during /_not-found prerendering, so static/nextra remains on 4.6.0.