### PR TITLE
Rollback Terragrunt version

### DIFF
--- a/infra/cloudsql/skeleton/Dockerfile
+++ b/infra/cloudsql/skeleton/Dockerfile
@@ -55,7 +55,7 @@ RUN curl -Lsfo opentofu.tgz "https://github.com/opentofu/opentofu/releases/downl
  && tofu version
 
 # Install terragrunt
-ARG TERRAGRUNT_VERSION=1.0.8
+ARG TERRAGRUNT_VERSION=0.92.1
 RUN curl -Lsfo terragrunt "https://github.com/gruntwork-io/terragrunt/releases/download/v${TERRAGRUNT_VERSION}/terragrunt_linux_$(uname -m | sed -e "s/aarch64/arm64/" -e "s/x86_64/amd64/")" \
  && install -o root -g root -m 0755 terragrunt /usr/local/bin/ \
  && rm terragrunt \

--- a/infra/tofu/skeleton/Dockerfile
+++ b/infra/tofu/skeleton/Dockerfile
@@ -27,7 +27,7 @@ RUN curl -Lsfo opentofu.tgz "https://github.com/opentofu/opentofu/releases/downl
  && tofu version
 
 # Install terragrunt
-ARG TERRAGRUNT_VERSION=1.0.8
+ARG TERRAGRUNT_VERSION=0.92.1
 RUN curl -Lsfo terragrunt "https://github.com/gruntwork-io/terragrunt/releases/download/v${TERRAGRUNT_VERSION}/terragrunt_linux_$(uname -m | sed -e "s/aarch64/arm64/" -e "s/x86_64/amd64/")" \
  && install -o root -g root -m 0755 terragrunt /usr/local/bin/ \
  && rm terragrunt \

--- a/infra/urlrouter/skeleton/Dockerfile
+++ b/infra/urlrouter/skeleton/Dockerfile
@@ -27,7 +27,7 @@ RUN curl -Lsfo opentofu.tgz "https://github.com/opentofu/opentofu/releases/downl
  && tofu version
 
 # Install terragrunt
-ARG TERRAGRUNT_VERSION=1.0.8
+ARG TERRAGRUNT_VERSION=0.92.1
 RUN curl -Lsfo terragrunt "https://github.com/gruntwork-io/terragrunt/releases/download/v${TERRAGRUNT_VERSION}/terragrunt_linux_$(uname -m | sed -e "s/aarch64/arm64/" -e "s/x86_64/amd64/")" \
  && install -o root -g root -m 0755 terragrunt /usr/local/bin/ \
  && rm terragrunt \


### PR DESCRIPTION
## Summary
- roll back infra template Terragrunt from `1.0.8` to `0.92.1`
- preserve existing `skip` behavior for missing infra config in generated apps

## Why
The reference app rollback showed Terragrunt `1.0.8` does not preserve the direct-apply skip behavior needed by these infra templates. This matches coreeng/core-platform-reference-applications#40.

## Verification
- `terragrunt 0.92.1 hcl validate` for infra/tofu skeleton
- `terragrunt 0.92.1 hcl validate` for infra/urlrouter skeleton
- `terragrunt 0.92.1 hcl validate` for infra/cloudsql skeleton
- `rtk make --no-print-directory templates-validate`
- `git diff --check`