### PR TITLE
Align Go lint image Alpine version

### DIFF
--- a/go/web/skeleton/Makefile
+++ b/go/web/skeleton/Makefile
@@ -30,7 +30,7 @@ lint-dockerfile: ## Run dockerfile lint checks
 
 .PHONY: lint-app
 lint-app: ## Run app lint checks
-	docker run --rm --mount type=bind,source=.,target=/app -w /app docker.io/golang:1.26.4-alpine3.23 sh -c "go install github.com/mgechev/revive@v1.15.0 && revive -config revive.toml -formatter stylish ./cmd/service/... ./cmd/handler/..."
+	docker run --rm --mount type=bind,source=.,target=/app -w /app docker.io/golang:1.26.4-alpine3.24 sh -c "go install github.com/mgechev/revive@v1.15.0 && revive -config revive.toml -formatter stylish ./cmd/service/... ./cmd/handler/..."
 
 .PHONY: lint
 lint: lint-config lint-dockerfile lint-app ## Run all lint checks


### PR DESCRIPTION
## Summary
- checked template dependency pins against latest stable releases per AGENTS.md
- held back nextra/nextra-theme-docs and Terragrunt as requested
- aligned the Go template lint image with the Alpine version used by the rest of the Go template

## Verification
- go get -u ./... && go mod tidy for Go app and Go test modules
- npm-check-updates and Yarn lock regeneration for Next.js and static Nextra templates
- uv lock for Python template
- tofu init -backend=false -upgrade for infra templates
- Docker manifest checks for core base image tags
- make lint-app in go/web/skeleton
- go test ./... in go/web/skeleton
- ./gradlew service:dependencies in java/web/skeleton
- git diff --check