### PR TITLE
Add app name to security scan workflows

### DIFF
--- a/docker/web/skeleton/.github/workflows/scheduled-security-scan.yaml
+++ b/docker/web/skeleton/.github/workflows/scheduled-security-scan.yaml
@@ -16,7 +16,7 @@ jobs:
     secrets:
       env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
     with:
-      app-name: {{ tenant }}
+      app-name: {{ name }}
       tenant-name: {{ tenant }}
       security-scan-blocking-severity: "off"
 {%- if working_directory is defined and working_directory %}

--- a/docker/web/skeleton/.github/workflows/scheduled-security-scan.yaml
+++ b/docker/web/skeleton/.github/workflows/scheduled-security-scan.yaml
@@ -16,6 +16,7 @@ jobs:
     secrets:
       env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
     with:
+      app-name: {{ tenant }}
       tenant-name: {{ tenant }}
       security-scan-blocking-severity: "off"
 {%- if working_directory is defined and working_directory %}

--- a/go/web/skeleton/.github/workflows/scheduled-security-scan.yaml
+++ b/go/web/skeleton/.github/workflows/scheduled-security-scan.yaml
@@ -16,7 +16,7 @@ jobs:
     secrets:
       env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
     with:
-      app-name: {{ tenant }}
+      app-name: {{ name }}
       tenant-name: {{ tenant }}
       security-scan-blocking-severity: "off"
 {%- if working_directory is defined and working_directory %}

--- a/go/web/skeleton/.github/workflows/scheduled-security-scan.yaml
+++ b/go/web/skeleton/.github/workflows/scheduled-security-scan.yaml
@@ -16,6 +16,7 @@ jobs:
     secrets:
       env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
     with:
+      app-name: {{ tenant }}
       tenant-name: {{ tenant }}
       security-scan-blocking-severity: "off"
 {%- if working_directory is defined and working_directory %}

--- a/infra/cloudsql/skeleton/.github/workflows/scheduled-security-scan.yaml
+++ b/infra/cloudsql/skeleton/.github/workflows/scheduled-security-scan.yaml
@@ -16,7 +16,7 @@ jobs:
     secrets:
       env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
     with:
-      app-name: {{ tenant }}
+      app-name: {{ name }}
       tenant-name: {{ tenant }}
       security-scan-blocking-severity: "off"
 {%- if working_directory is defined and working_directory %}

--- a/infra/cloudsql/skeleton/.github/workflows/scheduled-security-scan.yaml
+++ b/infra/cloudsql/skeleton/.github/workflows/scheduled-security-scan.yaml
@@ -16,6 +16,7 @@ jobs:
     secrets:
       env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
     with:
+      app-name: {{ tenant }}
       tenant-name: {{ tenant }}
       security-scan-blocking-severity: "off"
 {%- if working_directory is defined and working_directory %}

--- a/infra/tofu/skeleton/.github/workflows/scheduled-security-scan.yaml
+++ b/infra/tofu/skeleton/.github/workflows/scheduled-security-scan.yaml
@@ -16,7 +16,7 @@ jobs:
     secrets:
       env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
     with:
-      app-name: {{ tenant }}
+      app-name: {{ name }}
       tenant-name: {{ tenant }}
       security-scan-blocking-severity: "off"
 {%- if working_directory is defined and working_directory %}

--- a/infra/tofu/skeleton/.github/workflows/scheduled-security-scan.yaml
+++ b/infra/tofu/skeleton/.github/workflows/scheduled-security-scan.yaml
@@ -16,6 +16,7 @@ jobs:
     secrets:
       env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
     with:
+      app-name: {{ tenant }}
       tenant-name: {{ tenant }}
       security-scan-blocking-severity: "off"
 {%- if working_directory is defined and working_directory %}

--- a/infra/urlrouter/skeleton/.github/workflows/scheduled-security-scan.yaml
+++ b/infra/urlrouter/skeleton/.github/workflows/scheduled-security-scan.yaml
@@ -16,7 +16,7 @@ jobs:
     secrets:
       env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
     with:
-      app-name: {{ tenant }}
+      app-name: {{ name }}
       tenant-name: {{ tenant }}
       security-scan-blocking-severity: "off"
 {%- if working_directory is defined and working_directory %}

--- a/infra/urlrouter/skeleton/.github/workflows/scheduled-security-scan.yaml
+++ b/infra/urlrouter/skeleton/.github/workflows/scheduled-security-scan.yaml
@@ -16,6 +16,7 @@ jobs:
     secrets:
       env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
     with:
+      app-name: {{ tenant }}
       tenant-name: {{ tenant }}
       security-scan-blocking-severity: "off"
 {%- if working_directory is defined and working_directory %}

--- a/java/web/skeleton/.github/workflows/scheduled-security-scan.yaml
+++ b/java/web/skeleton/.github/workflows/scheduled-security-scan.yaml
@@ -16,7 +16,7 @@ jobs:
     secrets:
       env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
     with:
-      app-name: {{ tenant }}
+      app-name: {{ name }}
       tenant-name: {{ tenant }}
       security-scan-blocking-severity: "off"
 {%- if working_directory is defined and working_directory %}

--- a/java/web/skeleton/.github/workflows/scheduled-security-scan.yaml
+++ b/java/web/skeleton/.github/workflows/scheduled-security-scan.yaml
@@ -16,6 +16,7 @@ jobs:
     secrets:
       env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
     with:
+      app-name: {{ tenant }}
       tenant-name: {{ tenant }}
       security-scan-blocking-severity: "off"
 {%- if working_directory is defined and working_directory %}

--- a/nextjs/web/skeleton/.github/workflows/scheduled-security-scan.yaml
+++ b/nextjs/web/skeleton/.github/workflows/scheduled-security-scan.yaml
@@ -16,7 +16,7 @@ jobs:
     secrets:
       env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
     with:
-      app-name: {{ tenant }}
+      app-name: {{ name }}
       tenant-name: {{ tenant }}
       security-scan-blocking-severity: "off"
 {%- if working_directory is defined and working_directory %}

--- a/nextjs/web/skeleton/.github/workflows/scheduled-security-scan.yaml
+++ b/nextjs/web/skeleton/.github/workflows/scheduled-security-scan.yaml
@@ -16,6 +16,7 @@ jobs:
     secrets:
       env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
     with:
+      app-name: {{ tenant }}
       tenant-name: {{ tenant }}
       security-scan-blocking-severity: "off"
 {%- if working_directory is defined and working_directory %}

--- a/python/web/skeleton/.github/workflows/scheduled-security-scan.yaml
+++ b/python/web/skeleton/.github/workflows/scheduled-security-scan.yaml
@@ -16,7 +16,7 @@ jobs:
     secrets:
       env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
     with:
-      app-name: {{ tenant }}
+      app-name: {{ name }}
       tenant-name: {{ tenant }}
       security-scan-blocking-severity: "off"
 {%- if working_directory is defined and working_directory %}

--- a/python/web/skeleton/.github/workflows/scheduled-security-scan.yaml
+++ b/python/web/skeleton/.github/workflows/scheduled-security-scan.yaml
@@ -16,6 +16,7 @@ jobs:
     secrets:
       env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
     with:
+      app-name: {{ tenant }}
       tenant-name: {{ tenant }}
       security-scan-blocking-severity: "off"
 {%- if working_directory is defined and working_directory %}

--- a/static/nextra/skeleton/.github/workflows/scheduled-security-scan.yaml
+++ b/static/nextra/skeleton/.github/workflows/scheduled-security-scan.yaml
@@ -16,7 +16,7 @@ jobs:
     secrets:
       env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
     with:
-      app-name: {{ tenant }}
+      app-name: {{ name }}
       tenant-name: {{ tenant }}
       security-scan-blocking-severity: "off"
 {%- if working_directory is defined and working_directory %}

--- a/static/nextra/skeleton/.github/workflows/scheduled-security-scan.yaml
+++ b/static/nextra/skeleton/.github/workflows/scheduled-security-scan.yaml
@@ -16,6 +16,7 @@ jobs:
     secrets:
       env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
     with:
+      app-name: {{ tenant }}
       tenant-name: {{ tenant }}
       security-scan-blocking-severity: "off"
 {%- if working_directory is defined and working_directory %}


### PR DESCRIPTION
## Summary
- Add app-name input to scheduled security scan workflows
- Set app-name to the same template value as tenant-name

## Testing
- Verified diff contains only scheduled security scan workflow updates