### PR TITLE
Add Java web security ignore template

### DIFF
--- a/java/web/skeleton/.p2p-security-ignore.yaml
+++ b/java/web/skeleton/.p2p-security-ignore.yaml
@@ -1,0 +1,24 @@
+version: 1
+images:
+  - name: "{{ name }}"
+    secrets:
+      - id: p2psec_9756474ad1dca77c
+        path: /usr/lib/x86_64-linux-gnu/libgnutls.so.30.37.1
+        expires: 2026-09-23
+        reason: "Unverified Box pattern in Ubuntu libgnutls binary from the base image; no credential material is present and dependency upgrades already use the fixed available package revision."
+      - id: p2psec_d653005e4d23cf91
+        path: /usr/lib/x86_64-linux-gnu/libgnutls.so.30.37.1
+        expires: 2026-09-23
+        reason: "Unverified PrivateKey pattern in Ubuntu libgnutls binary from the base image; no credential material is present and dependency upgrades already use the fixed available package revision."
+      - id: p2psec_4d409f24673e54d7
+        path: /var/lib/dpkg/info/libc6:amd64.md5sums
+        expires: 2026-09-23
+        reason: "Unverified Box pattern in Ubuntu package checksum metadata from the base image; this is not an application secret."
+      - id: p2psec_0a7d3a58ac1bb931
+        path: /var/lib/dpkg/info/locales.md5sums
+        expires: 2026-09-23
+        reason: "Unverified Box pattern in Ubuntu package checksum metadata from the base image; this is not an application secret."
+      - id: p2psec_146d28c666737e01
+        path: /opt/java/openjdk/lib/server/libjvm.so
+        expires: 2026-09-23
+        reason: "Unverified Box pattern in the Eclipse Temurin JDK runtime library from the base image; this is not an application secret."


### PR DESCRIPTION
## Summary

Ports the completed reference-app fix from core-platform-reference-applications#49 into the Java web software template.

This change adds a template-local P2P security ignore file at java/web/skeleton/.p2p-security-ignore.yaml. The image name is templated as `{{ name }}`, so rendering the reference app produces `reference-java-web` while future Java web apps receive their own image name.

## Scope

- Template scope: java/web only.
- No other subprojects or templates were changed.
- Preserves the source PR intent: ignore the same unverified Java-web image-secret false positives, all expiring 2026-09-23.

## Validation

- YAML parse of java/web/skeleton/.p2p-security-ignore.yaml: passed.
- Rendered `{{ name }}` to `reference-java-web` and parsed the resulting YAML: passed.
- Applied the actual P2P ignore helper to source PR scan artifacts after rendering: fast-feedback active=0 ignored=6; extended-test active=0 ignored=6; prod active=0 ignored=6.
- `make templates-validate`: passed.