### PR TITLE
Port python web security scan ignores

### DIFF
--- a/python/web/skeleton/.p2p-security-ignore.yaml
+++ b/python/web/skeleton/.p2p-security-ignore.yaml
@@ -1,0 +1,25 @@
+---
+version: 1
+images:
+  - name: "{{ name }}"
+    secrets:
+      - id: p2psec_2e745269d2a106a0
+        path: /var/lib/dpkg/info/libc6:amd64.md5sums
+        expires: 2026-09-23
+        reason: "False positive in Debian libc package checksum metadata, not an application secret."
+      - id: p2psec_ae7c9f95165aff0b
+        path: /app/.venv/lib/python3.14/site-packages/pydantic/networks.py
+        expires: 2026-09-23
+        reason: "False positive from public URI examples in the packaged pydantic URL validation code."
+      - id: p2psec_7f935aceca16787b
+        path: /app/.venv/lib/python3.14/site-packages/pydantic/networks.py
+        expires: 2026-09-23
+        reason: "False positive from public URI examples in the packaged pydantic URL validation code."
+      - id: p2psec_ca89328d0d75906f
+        path: /app/.venv/lib/python3.14/site-packages/pydantic/networks.py
+        expires: 2026-09-23
+        reason: "False positive from public URI examples in the packaged pydantic URL validation code."
+      - id: p2psec_8f2fad8d82532ee3
+        path: /usr/local/lib/python3.14/site-packages/pip/_vendor/urllib3/util/url.py
+        expires: 2026-09-23
+        reason: "False positive from public URI parsing examples in pip's vendored urllib3 code."


### PR DESCRIPTION
## Summary

Ports the completed reference-app change from coreeng/core-platform-reference-applications#50 into the `python/web` software template only.

This adds a template-local `.p2p-security-ignore.yaml` under `python/web/skeleton/` so generated Python web apps receive the same image-secret false-positive ignores. The image name remains templated as `{{ name }}`, which renders to `reference-python-web` for the source reference app.

## Ignored findings

All entries expire on `2026-09-23`.

- `p2psec_2e745269d2a106a0` at `/var/lib/dpkg/info/libc6:amd64.md5sums`
- `p2psec_ae7c9f95165aff0b` at `/app/.venv/lib/python3.14/site-packages/pydantic/networks.py`
- `p2psec_7f935aceca16787b` at `/app/.venv/lib/python3.14/site-packages/pydantic/networks.py`
- `p2psec_ca89328d0d75906f` at `/app/.venv/lib/python3.14/site-packages/pydantic/networks.py`
- `p2psec_8f2fad8d82532ee3` at `/usr/local/lib/python3.14/site-packages/pip/_vendor/urllib3/util/url.py`

## Validation

- `ruby` YAML parse check passed for the raw template file: five image secret entries, image name `{{ name }}`, all expiring `2026-09-23`.
- `ruby` rendered-data comparison passed: substituting `{{ name }}` with `reference-python-web` matches the source PR ignore data.
- `docker run --rm --mount type=bind,source=/Users/ich776/.codex/worktrees/python-web-security-ignore-templates,target=/data docker.io/cytopia/yamllint -s python/web/skeleton/.p2p-security-ignore.yaml` passed.
- `make templates-validate` passed.
