### PR TITLE
Upgrade Java web Jackson dependencies

### DIFF
--- a/java/web/skeleton/service/build.gradle
+++ b/java/web/skeleton/service/build.gradle
@@ -16,6 +16,12 @@ repositories {
 	mavenCentral()
 }
 
+dependencyManagement {
+	imports {
+		mavenBom 'com.fasterxml.jackson:jackson-bom:2.22.0'
+	}
+}
+
 configurations {
 	implementations.exclude module: "spring-boot-starter-tomcat"
 }

--- a/java/web/skeleton/service/build.gradle
+++ b/java/web/skeleton/service/build.gradle
@@ -18,6 +18,7 @@ repositories {
 
 dependencyManagement {
 	imports {
+		// Temporary CVE-2026-54515 fix; remove when Spring Boot manages jackson-databind >= 2.21.5.
 		mavenBom 'com.fasterxml.jackson:jackson-bom:2.22.0'
 	}
 }


### PR DESCRIPTION
## Summary

Fixes the Java web image vulnerability reported by the reference-java-web security scan in core-platform-reference-applications run 28077318359.

The failing image policy job reported CVE-2026-54515 in `com.fasterxml.jackson.core:jackson-databind` `2.21.4`, fixed by `2.21.5` or newer. Spring Boot `4.1.0` is already the latest release, so this PR uses the existing Spring dependency-management plugin to import `com.fasterxml.jackson:jackson-bom:2.22.0` for the Java web template.

## Scope

- Template scope: `java/web` only.
- Changed only `java/web/skeleton/service/build.gradle`.
- No ignore entry was added because the finding is fixable by upgrading dependencies.

## Validation

- Downloaded and inspected the failing reference-app scan artifacts: `CVE-2026-54515`, `com.fasterxml.jackson.core:jackson-databind`, installed `2.21.4`, fixed `3.1.4, 2.18.9, 2.21.5`.
- Checked Maven Central metadata: Spring Boot Gradle plugin latest/release is `4.1.0`; Jackson Databind latest/release is `2.22.0`.
- `docker run --rm -v "$PWD/java/web/skeleton:/project" -w /project docker.io/gradle:9.5.1-jdk25-noble gradle service:dependencyInsight --dependency com.fasterxml.jackson.core:jackson-databind --configuration runtimeClasspath --no-daemon`: passed; resolved `com.fasterxml.jackson.core:jackson-databind:2.22.0`.
- `docker run --rm -v "$PWD/java/web/skeleton:/project" -w /project docker.io/gradle:9.5.1-jdk25-noble gradle service:build --no-daemon`: passed.
- `make templates-validate`: passed.
- `docker build --platform linux/amd64 --progress=plain -t java-web-template-jackson:security-scan java/web/skeleton`: passed; Gradle service build and tests passed inside the image build.
- `trivy image --format json --scanners vuln --severity UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL --exit-code 0 --ignore-unfixed java-web-template-jackson:security-scan`: passed with `0` vulnerabilities; Trivy detected `com.fasterxml.jackson.core:jackson-databind` `2.22.0` in `service.jar`.