### PR TITLE
Fix monitoring stack stage image builds

### DIFF
--- a/monitoring-stack/skeleton/Makefile
+++ b/monitoring-stack/skeleton/Makefile
@@ -38,13 +38,16 @@ build-integration:
 	docker buildx build $(p2p_image_cache) --tag "$(p2p_image_tag)" p2p/tests/integration/
 
 .PHONY: build-functional
-build-functional: build-integration
+build-functional:
+	docker buildx build $(p2p_image_cache) --tag "$(p2p_image_tag)" p2p/tests/integration/
 
 .PHONY: build-nft
-build-nft: build-integration
+build-nft:
+	docker buildx build $(p2p_image_cache) --tag "$(p2p_image_tag)" p2p/tests/integration/
 
 .PHONY: build-extended-test
-build-extended-test: build-integration
+build-extended-test:
+	docker buildx build $(p2p_image_cache) --tag "$(p2p_image_tag)" p2p/tests/integration/
 
 .PHONY: build-%
 build-%:


### PR DESCRIPTION
## Summary
- build the monitoring-stack test image separately for functional, NFT, and extended-test stages
- keep the same integration test Docker context while using each stage-specific p2p image tag

## Context
The generated Makefile made functional and NFT builds depend on build-integration. Since p2p.mk sets p2p_image_tag per stage, this built the integration image tag but later tried to push functional/NFT tags that did not exist locally.

## Verification
- ran git diff --check