### PR TITLE
Allow monitoring stack subnamespace creation

### DIFF
--- a/monitoring-stack/skeleton/.github/workflows/extended-test.yaml
+++ b/monitoring-stack/skeleton/.github/workflows/extended-test.yaml
@@ -30,7 +30,6 @@ jobs:
       tenant-name: {{ tenant }}
       version: {% raw %}${{ needs.get-latest-version.outputs.version }}{% endraw %}
       version-prefix: {{ version_prefix }}
-      skip-subnamespaces-create: true
 {%- if working_directory is defined and working_directory %}
       working-directory: {{ working_directory }}
 {%- endif %}

--- a/monitoring-stack/skeleton/.github/workflows/fast-feedback.yaml
+++ b/monitoring-stack/skeleton/.github/workflows/fast-feedback.yaml
@@ -41,7 +41,6 @@ jobs:
       app-name: {{ name }}
       tenant-name: {{ tenant }}
       version: {% raw %}${{ needs.version.outputs.version }}{% endraw %}
-      skip-subnamespaces-create: true
 {%- if working_directory is defined and working_directory %}
       working-directory: {{ working_directory }}
 {%- endif %}

--- a/monitoring-stack/skeleton/.github/workflows/prod.yaml
+++ b/monitoring-stack/skeleton/.github/workflows/prod.yaml
@@ -30,7 +30,6 @@ jobs:
       tenant-name: {{ tenant }}
       version: {% raw %}${{ needs.get-latest-version.outputs.version }}{% endraw %}
       version-prefix: {{ version_prefix }}
-      skip-subnamespaces-create: true
 {%- if working_directory is defined and working_directory %}
       working-directory: {{ working_directory }}
 {%- endif %}


### PR DESCRIPTION
## Summary
- remove skip-subnamespaces-create from monitoring-stack generated workflows
- allow p2p to create functional, NFT, integration, extended, and prod subnamespaces by default

## Context
The monitoring stack reference app failed because the generated workflows skipped p2p subnamespace creation even though the subnamespaces did not already exist.

## Verification
- ran git diff --check
- confirmed no monitoring-stack workflow template still sets skip-subnamespaces-create