### PR TITLE
Avoid monitoring stack stage resource collisions

### DIFF
--- a/monitoring-stack/skeleton/Makefile
+++ b/monitoring-stack/skeleton/Makefile
@@ -60,12 +60,20 @@ push-%:
 .PHONY: deploy-%
 deploy-%:
 	helm repo add core-platform-assets https://coreeng.github.io/core-platform-assets --force-update
+	stage="$*"; \
+	name_override="$(p2p_app_name)"; \
+	app_url_suffix="$(p2p_app_url_suffix)"; \
+	if [[ "$$stage" != "prod" ]]; then \
+		if [[ "$$stage" == "extended-test" ]]; then stage="extended"; fi; \
+		name_override="$(p2p_app_name)-$$stage"; \
+		app_url_suffix=""; \
+	fi; \
 	helm upgrade --install "$(p2p_app_name)" core-platform-assets/core-platform-monitoring -n "$(p2p_namespace)" \
 		-f <(envsubst < p2p/config/common.yaml) \
 		-f <(envsubst < p2p/config/$*.yaml) \
-		--set nameOverride="$(p2p_app_name)" \
+		--set nameOverride="$$name_override" \
 		--set tenantName="$(p2p_tenant_name)" \
-		--set ingress.appUrlSuffix="$(p2p_app_url_suffix)" \
+		--set ingress.appUrlSuffix="$$app_url_suffix" \
 		--set ingress.domain="$(INTERNAL_SERVICES_DOMAIN)" \
 		--atomic
 


### PR DESCRIPTION
## Summary
- use stage-specific chart names for non-prod monitoring-stack deploys
- keep prod using the base application name
- preserve the existing non-prod ingress hostnames by clearing the suffix when the stage is already included in nameOverride

## Context
Functional and NFT deploys can run in parallel. The monitoring chart creates parent-namespace RBAC named from nameOverride, so using the same nameOverride for every stage causes Helm ownership conflicts on resources such as Role reference-monitoring-stack-prometheus.

## Verification
- ran git diff --check