### PR TITLE
Make monitoring stack integration/prod only

### DIFF
--- a/monitoring-stack/skeleton/Makefile
+++ b/monitoring-stack/skeleton/Makefile
@@ -8,10 +8,7 @@ include .p2p.mk
 
 # Define required p2p targets
 p2p-build:         build-app           push-app
-p2p-functional:    build-functional    push-functional    deploy-functional    run-functional
-p2p-nft:           build-nft           push-nft           deploy-nft           run-nft
 p2p-integration:   build-integration   push-integration   deploy-integration   run-integration
-p2p-extended-test: build-extended-test push-extended-test deploy-extended-test run-extended-test
 p2p-prod:                                                 deploy-prod
 
 .PHONY: lint-config
@@ -35,18 +32,6 @@ build-app: lint ## Build app
 
 .PHONY: build-integration
 build-integration:
-	docker buildx build $(p2p_image_cache) --tag "$(p2p_image_tag)" p2p/tests/integration/
-
-.PHONY: build-functional
-build-functional:
-	docker buildx build $(p2p_image_cache) --tag "$(p2p_image_tag)" p2p/tests/integration/
-
-.PHONY: build-nft
-build-nft:
-	docker buildx build $(p2p_image_cache) --tag "$(p2p_image_tag)" p2p/tests/integration/
-
-.PHONY: build-extended-test
-build-extended-test:
 	docker buildx build $(p2p_image_cache) --tag "$(p2p_image_tag)" p2p/tests/integration/
 
 .PHONY: build-%
@@ -73,21 +58,9 @@ deploy-%:
 run-app: ## Run app
 	docker run --rm -P --name "$(p2p_app_name)" "$(p2p_image_tag)"
 
-.PHONY: run-functional
-run-functional:
-	bash p2p/scripts/helm-test.sh functional "$(p2p_namespace)" "$(p2p_app_name)" true
-
-.PHONY: run-nft
-run-nft:
-	bash p2p/scripts/helm-test.sh nft "$(p2p_namespace)" "$(p2p_app_name)" true
-
 .PHONY: run-integration
 run-integration:
 	bash p2p/scripts/helm-test.sh integration "$(p2p_namespace)" "$(p2p_app_name)" false
-
-.PHONY: run-extended-test
-run-extended-test:
-	bash p2p/scripts/helm-test.sh extended-test "$(p2p_namespace)" "$(p2p_app_name)" true
 
 .PHONY: run-%
 run-%:

--- a/monitoring-stack/skeleton/README.md
+++ b/monitoring-stack/skeleton/README.md
@@ -3,17 +3,14 @@
 Shared Core Platform monitoring stack.
 
 This repository is generated from the `monitoring-stack` software template. It deploys the
-`core-platform-assets/core-platform-monitoring` Helm chart through the standard P2P stages.
+`core-platform-assets/core-platform-monitoring` Helm chart through the integration and prod P2P stages.
 
 ## Deployment
 
 Use the generated P2P targets:
 
 ```bash
-make p2p-functional
-make p2p-nft
 make p2p-integration
-make p2p-extended-test
 make p2p-prod
 ```
 
@@ -85,6 +82,6 @@ named by `webhookSecretKey`. The template does not create Slack webhook secrets.
 
 ## P2P Validation
 
-The P2P functional, NFT, integration, and extended-test stages deploy this monitoring chart and then
-run `helm test` if the chart defines Helm test hooks. If the chart has no test hooks, the stage treats
-successful deployment as deploy-only validation.
+The P2P integration stage deploys this monitoring chart and then runs `helm test` if the chart defines
+Helm test hooks. If the chart has no test hooks, the stage treats successful deployment as deploy-only
+validation.

--- a/monitoring-stack/skeleton/p2p/config/extended-test.yaml
+++ b/monitoring-stack/skeleton/p2p/config/extended-test.yaml
@@ -1,6 +1,0 @@
----
-prometheus:
-  targetNamespaces:
-    - {{ name }}-integration
-  targetInstances:
-    - {{ name }}

--- a/monitoring-stack/skeleton/p2p/config/functional.yaml
+++ b/monitoring-stack/skeleton/p2p/config/functional.yaml
@@ -1,6 +1,0 @@
----
-prometheus:
-  targetNamespaces:
-    - {{ name }}-integration
-  targetInstances:
-    - {{ name }}

--- a/monitoring-stack/skeleton/p2p/config/nft.yaml
+++ b/monitoring-stack/skeleton/p2p/config/nft.yaml
@@ -1,6 +1,0 @@
----
-prometheus:
-  targetNamespaces:
-    - {{ name }}-integration
-  targetInstances:
-    - {{ name }}


### PR DESCRIPTION
## Summary
- remove functional, NFT, and extended-test deploy targets from the monitoring-stack template
- delete the unused functional, NFT, and extended-test Helm values files
- update the generated README to document integration/prod-only deployment

## Context
Derived monitoring stacks such as powerchainger-monitoring and elevate-infra only perform real deploys for integration and prod. Keeping functional/NFT/extended deploy targets on monitoring-stack causes duplicate Helm releases to compete for parent-namespace monitoring RBAC resources.

This PR leaves workflow templates unchanged. The p2p reusable workflows can still invoke the missing stage targets as no-ops, while integration remains the real fast-feedback deployment.

## Verification
- ran git diff --check
- ran make templates-validate