### PR TITLE
Add GCP Managed Kafka infra template

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@
 ├── static/nextra   — Nextra static documentation site
 └── infra/
     ├── cloudsql    — Cloud SQL infrastructure (OpenTofu)
+    ├── kafka       — GCP Managed Service for Apache Kafka infrastructure (OpenTofu)
     ├── tofu        — Generic OpenTofu infrastructure
     └── urlrouter   — URL router infrastructure
 ```

--- a/infra/kafka/skeleton/.editorconfig
+++ b/infra/kafka/skeleton/.editorconfig
@@ -1,0 +1,15 @@
+# EditorConfig is awesome: https://editorconfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+max_line_length = 120
+
+# Tab indentation (no size specified)
+[Makefile]
+indent_style = tab

--- a/infra/kafka/skeleton/.github/workflows/extended-test.yaml
+++ b/infra/kafka/skeleton/.github/workflows/extended-test.yaml
@@ -1,0 +1,36 @@
+---
+name: {{ name }} Extended Test
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 22 * * *"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  get-latest-version:
+    uses: coreeng/p2p/.github/workflows/p2p-get-latest-image-extended-test.yaml@v1
+    secrets:
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
+    with:
+      image-name: {{ name }}
+      tenant-name: {{ tenant }}
+
+  extendedtests:
+    needs: [get-latest-version]
+    uses: coreeng/p2p/.github/workflows/p2p-workflow-extended-test.yaml@v1
+    secrets:
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
+      env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
+    with:
+      app-name: {{ name }}
+      tenant-name: {{ tenant }}
+      version: {% raw %}${{ needs.get-latest-version.outputs.version }}{% endraw %}
+      version-prefix: {{ version_prefix }}
+      skip-subnamespaces-create: true
+{%- if working_directory is defined and working_directory %}
+      working-directory: {{ working_directory }}
+{%- endif %}

--- a/infra/kafka/skeleton/.github/workflows/fast-feedback.yaml
+++ b/infra/kafka/skeleton/.github/workflows/fast-feedback.yaml
@@ -1,0 +1,47 @@
+---
+name: {{ name }} Fast Feedback
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+{%- if working_directory is defined and working_directory %}
+    paths:
+      - {{ working_directory }}/**
+{%- endif %}
+  pull_request:
+    branches:
+      - main
+{%- if working_directory is defined and working_directory %}
+    paths:
+      - {{ working_directory }}/**
+{%- endif %}
+
+permissions:
+  contents: write
+  id-token: write
+  pull-requests: write
+
+jobs:
+  version:
+    uses: coreeng/p2p/.github/workflows/p2p-version.yaml@v1
+    with:
+      version-prefix: {{ version_prefix }}
+    secrets:
+      git-token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
+  fastfeedback:
+    needs: [version]
+    uses: coreeng/p2p/.github/workflows/p2p-workflow-fastfeedback.yaml@v1
+    secrets:
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
+      env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
+    with:
+      app-name: {{ name }}
+      tenant-name: {{ tenant }}
+      version: {% raw %}${{ needs.version.outputs.version }}{% endraw %}
+      skip-subnamespaces-create: true
+{%- if working_directory is defined and working_directory %}
+      working-directory: {{ working_directory }}
+{%- endif %}

--- a/infra/kafka/skeleton/.github/workflows/prod.yaml
+++ b/infra/kafka/skeleton/.github/workflows/prod.yaml
@@ -1,0 +1,36 @@
+---
+name: {{ name }} Prod
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "30 5 * * 1-5"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  get-latest-version:
+    uses: coreeng/p2p/.github/workflows/p2p-get-latest-image-prod.yaml@v1
+    secrets:
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
+    with:
+      image-name: {{ name }}
+      tenant-name: {{ tenant }}
+
+  prod:
+    needs: [get-latest-version]
+    uses: coreeng/p2p/.github/workflows/p2p-workflow-prod.yaml@v1
+    secrets:
+      slack_webhook_url: {% raw %}${{ secrets.P2P_SLACK_WEBHOOK_URL }}{% endraw %}
+      env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
+    with:
+      app-name: {{ name }}
+      tenant-name: {{ tenant }}
+      version: {% raw %}${{ needs.get-latest-version.outputs.version }}{% endraw %}
+      version-prefix: {{ version_prefix }}
+      skip-subnamespaces-create: true
+{%- if working_directory is defined and working_directory %}
+      working-directory: {{ working_directory }}
+{%- endif %}

--- a/infra/kafka/skeleton/.github/workflows/scheduled-security-scan.yaml
+++ b/infra/kafka/skeleton/.github/workflows/scheduled-security-scan.yaml
@@ -1,0 +1,24 @@
+---
+name: {{ name }} Security Scan
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 4 * * *"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  scheduled-security-scan:
+    uses: coreeng/p2p/.github/workflows/p2p-workflow-security-scan.yaml@v1
+    secrets:
+      env_vars: {% raw %}${{ secrets.env_vars }}{% endraw %}
+    with:
+      app-name: {{ name }}
+      tenant-name: {{ tenant }}
+      security-scan-blocking-severity: "off"
+{%- if working_directory is defined and working_directory %}
+      working-directory: {{ working_directory }}
+{%- endif %}

--- a/infra/kafka/skeleton/.gitignore
+++ b/infra/kafka/skeleton/.gitignore
@@ -1,0 +1,8 @@
+# p2p makefile
+.p2p.mk
+
+# vi swapfiles
+*.swp
+
+# hidden terraform cache and state directory
+infrastructure/code/.terraform

--- a/infra/kafka/skeleton/Dockerfile
+++ b/infra/kafka/skeleton/Dockerfile
@@ -1,0 +1,79 @@
+FROM docker.io/debian:trixie
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+WORKDIR /tmp
+
+# Install dependencies
+# hadolint ignore=DL3008
+RUN --mount=type=cache,target=/var/cache/apt \
+ apt-get update \
+ && apt-get install --no-install-recommends -y \
+  ca-certificates \
+  curl \
+  git \
+  gnupg \
+  jq \
+  make \
+  vim-tiny \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+# Install gcloud CLI
+ARG GCLOUD_CLI_VERSION=573.0.0
+VOLUME ["/root/.config/gcloud"]
+RUN --mount=type=cache,target=/var/cache/apt \
+ echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
+ && curl -Ls https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg \
+ && apt-get update \
+ && apt-get install --no-install-recommends -y \
+  google-cloud-cli=${GCLOUD_CLI_VERSION}-0 \
+  google-cloud-cli-gke-gcloud-auth-plugin=${GCLOUD_CLI_VERSION}-0 \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* \
+ && gcloud config set core/disable_usage_reporting true \
+ && gcloud config set component_manager/disable_update_check true \
+ && gcloud config set metrics/environment github_docker_image \
+ && gcloud --version \
+ && find /usr/lib/google-cloud-sdk -name '*.pyc' -delete \
+ && find /usr/lib/google-cloud-sdk -name '*__pycache__*' -delete
+
+# Install opentofu
+ARG OPENTOFU_VERSION=1.12.3
+RUN curl -Lsfo opentofu.tgz "https://github.com/opentofu/opentofu/releases/download/v${OPENTOFU_VERSION}/tofu_${OPENTOFU_VERSION}_linux_$(uname -m | sed -e "s/aarch64/arm64/" -e "s/x86_64/amd64/").tar.gz" \
+ && tar zxf opentofu.tgz tofu \
+ && install -o root -g root -m 0755 tofu /usr/local/bin/ \
+ && rm opentofu.tgz tofu \
+ && tofu version
+
+# Install terragrunt
+ARG TERRAGRUNT_VERSION=0.92.1
+RUN curl -Lsfo terragrunt "https://github.com/gruntwork-io/terragrunt/releases/download/v${TERRAGRUNT_VERSION}/terragrunt_linux_$(uname -m | sed -e "s/aarch64/arm64/" -e "s/x86_64/amd64/")" \
+ && install -o root -g root -m 0755 terragrunt /usr/local/bin/ \
+ && rm terragrunt \
+ && terragrunt -version
+
+# Install yq
+ARG YQ_VERSION=4.53.3
+RUN curl -Lso yq "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_$(uname -m | sed -e "s/aarch64/arm64/" -e "s/x86_64/amd64/")" \
+ && install -o root -g root -m 0755 yq /usr/local/bin/ \
+ && rm yq \
+ && yq --version
+
+WORKDIR /app
+
+# Copy infrastructure
+COPY infrastructure/ ./
+
+# Check tf & tg formatting
+RUN tofu fmt -check -diff -recursive && terragrunt hcl fmt --check
+
+# Cache terraform providers, and persist cache in the image
+RUN --mount=type=cache,target=/var/tmp/terraform TF_PLUGIN_CACHE_DIR=/var/tmp/terraform ENV=cache make infra-init-cache \
+ && cp -R /var/tmp/terraform /var/cache/terraform
+ENV TF_PLUGIN_CACHE_DIR=/var/cache/terraform
+ENV CHECKPOINT_DISABLE=true
+
+# Set version
+ARG P2P_VERSION
+ENV P2P_VERSION=${P2P_VERSION}

--- a/infra/kafka/skeleton/Makefile
+++ b/infra/kafka/skeleton/Makefile
@@ -1,0 +1,95 @@
+# Set tenant and app name
+P2P_TENANT_NAME ?= {{ tenant }}
+P2P_APP_NAME ?= {{ name }}
+
+# Download and include p2p makefile
+$(shell curl -fsSL "https://raw.githubusercontent.com/coreeng/p2p/v1/p2p.mk" -o ".p2p.mk")
+include .p2p.mk
+
+# Define required p2p targets
+p2p-build:         build-app           push-app
+p2p-functional:    build-functional    push-functional    deploy-functional    run-functional
+p2p-nft:           build-nft           push-nft           deploy-nft           run-nft
+p2p-integration:   build-integration   push-integration   deploy-integration   run-integration
+p2p-extended-test: build-extended-test push-extended-test deploy-extended-test run-extended-test
+p2p-prod:                                                 deploy-prod
+
+
+
+.PHONY: lint-config
+lint-config: ## Run config lint checks
+	docker run --rm --mount type=bind,source=./p2p/config,target=/data docker.io/cytopia/yamllint -s .
+
+.PHONY: lint-dockerfile
+lint-dockerfile: ## Run dockerfile lint checks
+	docker run --rm -i docker.io/hadolint/hadolint < Dockerfile
+
+.PHONY: lint-app
+lint-app: ## Run app lint checks
+	docker run --rm --workdir=/srv/workspace --mount type=bind,source=.,target=/srv/workspace ghcr.io/opentofu/opentofu:latest fmt -check -diff -recursive
+	docker run --rm --workdir=/srv/workspace --mount type=bind,source=.,target=/srv/workspace alpine/terragrunt:latest terragrunt hcl fmt --check
+
+.PHONY: lint
+lint: lint-config lint-dockerfile lint-app ## Run all lint checks
+
+
+
+.PHONY: build-app
+build-app: lint ## Build app
+	docker buildx build $(p2p_image_cache) \
+		--tag "$(p2p_image_tag)" \
+		--build-arg P2P_VERSION="$(p2p_version)" \
+		--file Dockerfile .
+
+.PHONY: build-%
+build-%:
+	@echo "WARNING: $@ not implemented"
+
+
+
+.PHONY: push-app
+push-app:
+	docker image push "$(p2p_image_tag)"
+
+.PHONY: push-%
+push-%:
+	@echo "WARNING: $@ not implemented"
+
+
+
+.PHONY: deploy-%
+deploy-%:
+	if [ -n "$(CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE)" ] ; then \
+		mkdir -p ~/.config/gcloud ; \
+		cat $(CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE) >> ~/.config/gcloud/application_default_credentials.json ; \
+	fi
+	docker run --rm -P --name "$(p2p_app_name)" \
+		-v ~/.config/gcloud/:/root/.config/gcloud \
+		-v "${PWD}/p2p/config/common.yaml:/app/common.yaml" \
+		-v "${PWD}/p2p/config/$*.yaml:/app/config.yaml" \
+		-e environment=$* \
+		-e tenant_name=$(p2p_tenant_name) \
+		-e app_name=$(p2p_app_name) \
+		"$(p2p_registry)/$(p2p_app_name):$(p2p_version)" \
+		make infra-apply
+
+
+
+.PHONY: run-app
+run-app: run-functional-app ## Run app
+
+.PHONY: run-%-app
+run-%-app:
+	docker run --rm -P -it --name "$(p2p_app_name)-$*" \
+		-v ~/.config/gcloud/:/root/.config/gcloud \
+		-v "${PWD}/p2p/config/common.yaml:/app/common.yaml" \
+		-v "${PWD}/p2p/config/$*.yaml:/app/config.yaml" \
+		-e environment=$* \
+		-e tenant_name=$(p2p_tenant_name) \
+		-e app_name=$(p2p_app_name) \
+		"$(p2p_image_tag)" \
+		bash
+
+.PHONY: run-%
+run-%:
+	@echo "WARNING: $@ not implemented"

--- a/infra/kafka/skeleton/README.md
+++ b/infra/kafka/skeleton/README.md
@@ -1,0 +1,76 @@
+# {{ name }}
+
+Infrastructure provisioning application for Core Platform GCP Managed Service for Apache Kafka.
+
+This repository is generated with the Kafka template. Before the Path to Production workflows can provision anything, fill in the GCP projects, connected platform subnet, client service account, topics, and ACLs under `p2p/config/`.
+
+## Required Configuration
+
+Collect these values before enabling the pipeline:
+
+| Field | Integration | Prod |
+|---|---|---|
+| Infra project ID | GCP project where integration Kafka clusters and Terraform state are created | GCP project where production Kafka clusters and Terraform state are created |
+| Platform project ID | Core Platform project where the consuming GKE pods run | Core Platform production project where the consuming GKE pods run |
+| Region | GCP region for Kafka, connected subnets, and Terraform state, for example `europe-west2` | Same region unless production needs a different location |
+| Connected subnet | Subnet in the platform/GKE VPC that Managed Kafka connects to | Production platform/GKE subnet |
+| Kafka cluster name | Kafka cluster base name | Usually the same value as integration |
+| App service account email | Cloud access GCP service account used by the application pods | Production cloud access GCP service account |
+| Topics and ACLs | Kafka topics and authorizations required by the application | Production topics and authorizations |
+
+## Network Connectivity
+
+The Kafka cluster is created in `infrastructure_project_id`, but the pods connect through a subnet in `platform_project_id`.
+
+Managed Kafka creates Private Service Connect endpoints and DNS records automatically in each connected VPC network. This template does not create PSC endpoints directly; it attaches the configured subnets to the Kafka cluster.
+
+Pods can connect when:
+
+- The cluster has a connected subnet from the platform/GKE VPC.
+- The connected subnet is in the same region as the Kafka cluster.
+- The Kafka service agent from the infra project has `roles/managedkafka.serviceAgent` on the platform project.
+- Egress to Kafka port `9092` is allowed by platform network policy and firewall rules.
+- Pods use the bootstrap address reported by Managed Kafka after the cluster is created.
+
+## Authentication And Authorization
+
+Application pods should use their Core Platform cloud access GCP service account for IAM-backed Kafka broker authentication.
+
+The template grants each configured `client_principals` entry `roles/managedkafka.client` in the infra project. Kafka ACLs are configured separately and authorize operations on Kafka resources such as topics and consumer groups.
+
+For service account clients, use:
+
+```text
+client_principals: serviceAccount:<service-account-email>
+Kafka ACL principal: User:<service-account-email>
+```
+
+## Temporary Sample Configuration
+
+The generated template currently includes a sample `kafka` block in `p2p/config/common.yaml` for testing. Replace it with real values before provisioning.
+
+## Configure Stage Projects
+
+Set project IDs in every stage that should deploy Kafka. The generated template includes these files:
+
+- `p2p/config/functional.yaml`
+- `p2p/config/integration.yaml`
+- `p2p/config/nft.yaml`
+- `p2p/config/extended-test.yaml`
+- `p2p/config/prod.yaml`
+
+Example:
+
+```yaml
+---
+infrastructure_project_id: my-app-dev-infra
+platform_project_id: core-platform-dev
+```
+
+Terragrunt skips provisioning until all required bootstrap values are present:
+
+- `region`
+- `infrastructure_project_id`
+- `platform_project_id`
+
+Kafka resources are only created when `kafka.enabled` is `true` and at least one cluster is configured.

--- a/infra/kafka/skeleton/infrastructure/Makefile
+++ b/infra/kafka/skeleton/infrastructure/Makefile
@@ -1,0 +1,57 @@
+# IaC path
+IAC_PATH=code
+
+SERVICE_PROJECT_ID := \
+	$$(yq '.infrastructure_project_id' -o t config.yaml)
+
+
+
+.PHONY: help
+help:
+	@echo "Usage:"
+	@grep -E '^[a-zA-Z1-9_-]+:.*?## .*$$' -h $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  make %-30s %s\n", $$1, $$2}'
+
+
+
+.PHONY: infra-init-cache
+infra-init-cache:
+	tofu -chdir="$(IAC_PATH)" init -lock=false -backend=false
+	rm -rf "$(IAC_PATH)/.terraform"
+
+.PHONY: infra-init-upgrade
+infra-init-upgrade:
+	tofu -chdir="$(IAC_PATH)" init -lock=false -backend=false -upgrade
+	tofu -chdir="$(IAC_PATH)" providers lock --platform=darwin_amd64 --platform=darwin_arm64 --platform=linux_amd64 --platform=linux_arm64 --platform=windows_amd64
+	rm -rf "$(IAC_PATH)/.terraform"
+
+.PHONY: infra-init
+infra-init: ## Terragrunt init
+	terragrunt init --working-dir="$(IAC_PATH)" --non-interactive --backend-bootstrap -lock=false
+
+.PHONY: infra-plan
+infra-plan: ## Terragrunt plan
+	@export USER_PROJECT_OVERRIDE=true ; \
+	export GOOGLE_BILLING_PROJECT=$(SERVICE_PROJECT_ID) ; \
+	terragrunt plan --working-dir="$(IAC_PATH)" --non-interactive --backend-bootstrap -lock=false -out="plan.zip"
+
+.PHONY: infra-refresh
+infra-refresh: ## Terragrunt refresh
+	@export USER_PROJECT_OVERRIDE=true ; \
+	export GOOGLE_BILLING_PROJECT=$(SERVICE_PROJECT_ID) ; \
+	terragrunt refresh --working-dir="$(IAC_PATH)" --non-interactive --backend-bootstrap
+
+.PHONY: infra-apply
+infra-apply: ## Terragrunt apply
+	@export USER_PROJECT_OVERRIDE=true ; \
+	export GOOGLE_BILLING_PROJECT=$(SERVICE_PROJECT_ID) ; \
+	terragrunt apply --working-dir="$(IAC_PATH)" --non-interactive --backend-bootstrap -auto-approve
+
+.PHONY: infra-destroy
+infra-destroy: ## Terragrunt destroy
+	@export USER_PROJECT_OVERRIDE=true ; \
+	export GOOGLE_BILLING_PROJECT=$(SERVICE_PROJECT_ID) ; \
+	terragrunt destroy --working-dir="$(IAC_PATH)" --non-interactive -auto-approve
+
+.PHONY: infra-output
+infra-output: ## Terragrunt output
+	terragrunt output --working-dir="$(IAC_PATH)"

--- a/infra/kafka/skeleton/infrastructure/code/.terraform.lock.hcl
+++ b/infra/kafka/skeleton/infrastructure/code/.terraform.lock.hcl
@@ -1,0 +1,76 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/google" {
+  version     = "7.37.0"
+  constraints = ">= 3.43.0, 7.37.0, < 8.0.0"
+  hashes = [
+    "h1:0P4t79IWJhZUvS0YjOyCn591GIJeyl9vmm5BzrnFFIY=",
+    "h1:5PihSPxYLrd0u4e69rX4zUUCzZhqG90DKvPue3GgvM4=",
+    "h1:7JjDoauKESSOI7q6OqV4SfGUslAtOQd3v/sBoGnIbEM=",
+    "h1:9y48Rq0fuLtBxJyp9qHU0AqPWJv3QtYB18/lYYnEiPU=",
+    "h1:FMnbZ/gtLzzhhH4C0Ht3ZCb8afG7Rw4BE5LD8s5Ge7I=",
+    "h1:I1A9pCgQmIXhAcpJzDvyzmDaPFqBA2yICymEyuxIRoc=",
+    "h1:NfJHybSo33xSR0a/oS6B+lWDLquGmqYsNviF6kw4JUc=",
+    "h1:RvBGaj3aR2sFMDRrHdC+knQqHUuteep69EER781c3X8=",
+    "h1:SFP7uUJNCfWg2qZGm3P6OS66Q+qGiP9LC/V363ayMYk=",
+    "h1:W7lphPXlXb3kA9YcPTgPHoRkB1c+f1mY7aZbO/3M/Lo=",
+    "h1:gSj3fe/OZlKJ4zPZw+xxSnpBt5wuzjaW9aYJYq2qQM4=",
+    "h1:iTYjwnM3Eue0KGtsf2ZH3qJEQmskKG951Von4fNQEX8=",
+    "h1:jzIoxw6AOozHjmmFv9j7dqSY+1vNtr/PrTBsuC7kvRE=",
+    "h1:n5AHcJBaST4GIOAvtuMgcFAtojo3rh+YBswDjDjVML0=",
+    "h1:zqpwO5C2419m6EVCOFoD9uQrqe5WNae9LhQ0Syhc5Ds=",
+    "zh:3bdd1b931c72ca69c3a4ae3a2d5b7ed35694866382c72df4fe1f7c7333cf67c0",
+    "zh:4ab8fb029efa086700c59a0dcd891f38fc81c747575bf8f2b1083727ebe3bf75",
+    "zh:53a29b15a7d696790dcad12cfb0ae9730be3e54bdbdd9dc185f0869f9e2fa716",
+    "zh:5aa5215fb457bfd466860ed545c0b5820a71ab265065a88f9fc09dbaafef2a45",
+    "zh:8380b9ae5c893b158798aba7e6d930ad6fcbfd6d0ef22122ec55decc3b73ea55",
+    "zh:8e92d589fbad49ce14a7faa1d893588786deea2d11b544a77bae50d61d71696d",
+    "zh:9e853676276699ea2dcf8de07ab361677a16bde470ff48a07db930a7b47d0fc1",
+    "zh:ad8b47043bfc0e759220f06de35c5c8958abe2cd8fc1d74dde52aaf8d79b0684",
+    "zh:aff75581d6e0d259d29a3cf62d915d6d7d5a097fd72915db5d576137a11fc62c",
+    "zh:b7c8b9b9d019d4727e3ba0c29186f4bc8567c0393f14a15f70cf2ec6267e0d0a",
+    "zh:cfc6869f88141c6a9cb2476e2e2e07410521a4b028e9f9b604f70976158f2c1e",
+    "zh:d30b04b4290b34cc11fdcf60f8267d4c315bd9f77fd491532d311ff3ac736a6f",
+    "zh:d7a0231ff91b1c99f9efe77f78260603e23154d38ea43c9a238ebcc77cc5f027",
+    "zh:dfd606cd787f5b6bb86354eaa3b9139c3d5e3f664912a0caadbcead6709fad50",
+    "zh:f853da41c3e431a693a3e9435c33a369371063fe1817ae27216a66a4ca20bddb",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/google-beta" {
+  version     = "7.37.0"
+  constraints = ">= 3.43.0, 7.37.0, < 8.0.0"
+  hashes = [
+    "h1:5MMOVAi1FPEXVEgxZafHBahXaKxEAml1MRxX4dtPp8Q=",
+    "h1:AKdxM/yTOqJXkqIZXc6Zft5aP30ixxI+NTN6Jec8wEk=",
+    "h1:BxOP/GRUARf9UIXC3GFxf+PmAyCeRlz6Awmw2cZnmhY=",
+    "h1:CBdP8GgBbS3XVlPB3shLgPTFgPLQwd/XbVTscppHrTw=",
+    "h1:FktYXRLQkroxJaqPQdaryM64muGO4uiRbHjn0w2DQDc=",
+    "h1:Jtj7xrRLt5zUWhMS3H22A2AU0a9GSc4kYtLbtTZhmPs=",
+    "h1:OHP53pHMiLEBI6v8nJ8tzJmC6xtwd/a9ktcsCvFesRc=",
+    "h1:PDPcXupf+GYHdGyV/V+mCXQ9QTZvVbvph6XxSlC5zPU=",
+    "h1:TVuVxP5/kVNwaelqBZSrfhCHNMg4nlq84FML6g6tVbA=",
+    "h1:cjZvH+laKbWACiJq+696cLavkNCrkuEmezIrXDMustI=",
+    "h1:dR+dQD6Ww2ioESNyWsbjE6T8GOqSBDLpZ2CTG6+h2qc=",
+    "h1:nWVOXTomo9XjO4syQNhr3+y1TcWYa0fTBGIGvrEH6iw=",
+    "h1:pcRaRFQxsZDK0Hu77uJY+JbFclWwC45w753OxY5yyIo=",
+    "h1:rAO4AX+2lMdJuxrH0UqXPRGBkmOHL2c91rVu/j4Ef/Y=",
+    "h1:yLqsKrl7XuPNuo3tsUo1GnJujE74gPPJq90dqo9p6ew=",
+    "zh:30609e5de7ab10f50a4e61bd4b1181c82b8a8d8ffd348e1b97b5a6b79fa186fc",
+    "zh:370f44e63296c16f329975034423d8a24e3cd13ff62edbe75a3e4903a5ecd0a4",
+    "zh:4966991a3b6a7a2505a9d8ae670a47f10042a2e83877d0de047bdbc2d30f8ab6",
+    "zh:6b73ca67d602d5894789769db82c5130bda190b65d8c6dcb706341ebf259c858",
+    "zh:8e23f619dad482694eeb340565863bb1b634188195590cd4c9654f1bef950f2c",
+    "zh:921fdd2c67e204091e2fc653ef75d2039c1e04a5ff9dedaf42ca3c46876a331f",
+    "zh:9a125d786269d09f8a449a4cff3460ec1a36691677f9d5a3f575b1e6e357955f",
+    "zh:b53725b22c58379c5aa8e165e8bfa916219ab895cfaf1017974de12ccf69fa81",
+    "zh:b6c982f1f0eff57ee56b9f2a73f02d84d104e20615887c81549a53a93f513668",
+    "zh:b75aa5328bd2fe86e575bd69c1a6ae582e23d6507df5a8e5328d81dfbba36749",
+    "zh:c0f5bdef5222c2c8aa393b5c8b4b5f21b4541a1c4971bc4adce7744dbc2c481f",
+    "zh:ca71a04995ed4f2d2f6a9d0f9d2fc2da831a63ba1742692285dbf98007b610e4",
+    "zh:ccafa8518580181286e6e53c89f746379086d79c96cfa5ae0b962b03797584c0",
+    "zh:e24bb2b7c858d66fedf48670d8042aab52733b6a3ec2cacc63984996f3779bf3",
+    "zh:fb16cc5ac5627df6ad7a499687173944f888eced2e11f898df28da9f0281a6d7",
+  ]
+}

--- a/infra/kafka/skeleton/infrastructure/code/backend.tf
+++ b/infra/kafka/skeleton/infrastructure/code/backend.tf
@@ -1,0 +1,6 @@
+# Terragrunt remote_state is used in terragrunt.hcl to configure remote state configuration
+# https://terragrunt.gruntwork.io/docs/reference/config-blocks-and-attributes/#remote_state
+
+terraform {
+  backend "gcs" {}
+}

--- a/infra/kafka/skeleton/infrastructure/code/kafka.tf
+++ b/infra/kafka/skeleton/infrastructure/code/kafka.tf
@@ -1,0 +1,69 @@
+variable "kafka" {
+  description = "Managed Kafka configuration"
+  type = object({
+    enabled = bool
+    clusters = optional(list(object({
+      name            = string
+      vcpu_count      = number
+      memory_bytes    = number
+      deletion_policy = optional(string, "PREVENT")
+      labels          = optional(map(string), {})
+      rebalance_mode  = optional(string, "AUTO_REBALANCE_ON_SCALE_UP")
+      connected_subnets = list(object({
+        subnet                   = string
+        project_id               = optional(string)
+        grant_service_agent_role = optional(bool, true)
+      }))
+      client_principals = optional(list(string), [])
+      topics = optional(list(object({
+        name               = string
+        partition_count    = optional(number)
+        replication_factor = optional(number, 3)
+        configs            = optional(map(string), {})
+        deletion_policy    = optional(string, "PREVENT")
+      })), [])
+      acls = optional(list(object({
+        id              = string
+        deletion_policy = optional(string, "PREVENT")
+        entries = list(object({
+          principal       = string
+          operation       = string
+          permission_type = optional(string, "ALLOW")
+          host            = optional(string, "*")
+        }))
+      })), [])
+    })), [])
+  })
+
+  validation {
+    condition = alltrue([
+      for cluster in var.kafka.clusters : contains(["MODE_UNSPECIFIED", "NO_REBALANCE", "AUTO_REBALANCE_ON_SCALE_UP"], cluster.rebalance_mode)
+    ])
+    error_message = "kafka.clusters[*].rebalance_mode must be MODE_UNSPECIFIED, NO_REBALANCE, or AUTO_REBALANCE_ON_SCALE_UP."
+  }
+
+  validation {
+    condition = alltrue(flatten([
+      for cluster in var.kafka.clusters : [
+        for policy in concat([cluster.deletion_policy], [for topic in cluster.topics : topic.deletion_policy], [for acl in cluster.acls : acl.deletion_policy]) : contains(["DELETE", "PREVENT", "ABANDON"], policy)
+      ]
+    ]))
+    error_message = "Kafka deletion_policy values must be DELETE, PREVENT, or ABANDON."
+  }
+}
+
+module "kafka" {
+  source = "./modules/kafka"
+  count  = var.kafka.enabled ? 1 : 0
+
+  infrastructure_project_id = var.infrastructure_project_id
+  platform_project_id       = var.platform_project_id
+  environment               = var.environment
+  region                    = var.region
+  kafka                     = var.kafka
+}
+
+output "kafka_clusters" {
+  description = "Managed Kafka cluster resource names"
+  value       = var.kafka.enabled ? module.kafka[0].clusters : {}
+}

--- a/infra/kafka/skeleton/infrastructure/code/modules/kafka/apis.tf
+++ b/infra/kafka/skeleton/infrastructure/code/modules/kafka/apis.tf
@@ -1,0 +1,15 @@
+module "project-services" {
+  source  = "terraform-google-modules/project-factory/google//modules/project_services"
+  version = "18.1.0"
+
+  project_id = var.infrastructure_project_id
+
+  disable_dependent_services  = false
+  disable_services_on_destroy = false
+
+  activate_apis = [
+    "cloudresourcemanager.googleapis.com",
+    "compute.googleapis.com",
+    "managedkafka.googleapis.com",
+  ]
+}

--- a/infra/kafka/skeleton/infrastructure/code/modules/kafka/locals.tf
+++ b/infra/kafka/skeleton/infrastructure/code/modules/kafka/locals.tf
@@ -1,0 +1,43 @@
+locals {
+  clusters = {
+    for cluster in var.kafka.clusters : cluster.name => merge(cluster, {
+      cluster_id = "${cluster.name}-${var.environment}-cluster"
+    })
+  }
+
+  connected_subnets = flatten([
+    for cluster_name, cluster in local.clusters : [
+      for subnet in cluster.connected_subnets : merge(subnet, {
+        cluster_name = cluster_name
+        project_id   = coalesce(try(subnet.project_id, null), var.platform_project_id)
+      })
+    ]
+  ])
+
+  service_agent_project_grants = toset([
+    for subnet in local.connected_subnets : subnet.project_id
+    if subnet.grant_service_agent_role
+  ])
+
+  client_principals = toset(distinct(flatten([
+    for cluster in local.clusters : cluster.client_principals
+  ])))
+
+  topics = merge({}, [
+    for cluster_name, cluster in local.clusters : {
+      for topic in cluster.topics : "${cluster_name}/${topic.name}" => merge(topic, {
+        cluster_name = cluster_name
+        cluster_id   = cluster.cluster_id
+      })
+    }
+  ]...)
+
+  acls = merge({}, [
+    for cluster_name, cluster in local.clusters : {
+      for acl in cluster.acls : "${cluster_name}/${acl.id}" => merge(acl, {
+        cluster_name = cluster_name
+        cluster_id   = cluster.cluster_id
+      })
+    }
+  ]...)
+}

--- a/infra/kafka/skeleton/infrastructure/code/modules/kafka/main.tf
+++ b/infra/kafka/skeleton/infrastructure/code/modules/kafka/main.tf
@@ -1,0 +1,99 @@
+resource "google_project_service_identity" "managed_kafka" {
+  provider = google-beta
+
+  project = var.infrastructure_project_id
+  service = "managedkafka.googleapis.com"
+
+  depends_on = [module.project-services]
+}
+
+resource "google_project_iam_member" "managed_kafka_service_agent" {
+  for_each = local.service_agent_project_grants
+
+  project = each.value
+  role    = "roles/managedkafka.serviceAgent"
+  member  = "serviceAccount:${google_project_service_identity.managed_kafka.email}"
+}
+
+resource "google_managed_kafka_cluster" "cluster" {
+  for_each = local.clusters
+
+  project         = var.infrastructure_project_id
+  cluster_id      = each.value.cluster_id
+  location        = var.region
+  labels          = each.value.labels
+  deletion_policy = each.value.deletion_policy
+
+  capacity_config {
+    vcpu_count   = each.value.vcpu_count
+    memory_bytes = each.value.memory_bytes
+  }
+
+  gcp_config {
+    access_config {
+      dynamic "network_configs" {
+        for_each = each.value.connected_subnets
+        content {
+          subnet = network_configs.value.subnet
+        }
+      }
+    }
+  }
+
+  rebalance_config {
+    mode = each.value.rebalance_mode
+  }
+
+  depends_on = [
+    module.project-services,
+    google_project_iam_member.managed_kafka_service_agent,
+  ]
+}
+
+resource "google_project_iam_member" "managed_kafka_client" {
+  for_each = local.client_principals
+
+  project = var.infrastructure_project_id
+  role    = "roles/managedkafka.client"
+  member  = each.value
+}
+
+resource "google_managed_kafka_topic" "topic" {
+  for_each = local.topics
+
+  project            = var.infrastructure_project_id
+  location           = var.region
+  cluster            = each.value.cluster_id
+  topic_id           = each.value.name
+  partition_count    = each.value.partition_count
+  replication_factor = each.value.replication_factor
+  configs            = each.value.configs
+  deletion_policy    = each.value.deletion_policy
+
+  depends_on = [google_managed_kafka_cluster.cluster]
+}
+
+resource "google_managed_kafka_acl" "acl" {
+  for_each = local.acls
+
+  project         = var.infrastructure_project_id
+  location        = var.region
+  cluster         = each.value.cluster_id
+  acl_id          = each.value.id
+  deletion_policy = each.value.deletion_policy
+
+  dynamic "acl_entries" {
+    for_each = each.value.entries
+    content {
+      principal       = acl_entries.value.principal
+      operation       = acl_entries.value.operation
+      permission_type = acl_entries.value.permission_type
+      host            = acl_entries.value.host
+    }
+  }
+
+  depends_on = [
+    google_managed_kafka_cluster.cluster,
+    google_managed_kafka_topic.topic,
+  ]
+}

--- a/infra/kafka/skeleton/infrastructure/code/modules/kafka/outputs.tf
+++ b/infra/kafka/skeleton/infrastructure/code/modules/kafka/outputs.tf
@@ -1,0 +1,6 @@
+output "clusters" {
+  description = "Managed Kafka cluster resource names by configured cluster name"
+  value = {
+    for name, cluster in google_managed_kafka_cluster.cluster : name => cluster.name
+  }
+}

--- a/infra/kafka/skeleton/infrastructure/code/modules/kafka/variables.tf
+++ b/infra/kafka/skeleton/infrastructure/code/modules/kafka/variables.tf
@@ -1,0 +1,53 @@
+variable "infrastructure_project_id" {
+  type = string
+}
+
+variable "platform_project_id" {
+  type = string
+}
+
+variable "environment" {
+  type = string
+}
+
+variable "region" {
+  type = string
+}
+
+variable "kafka" {
+  description = "Managed Kafka configuration"
+  type = object({
+    enabled = bool
+    clusters = optional(list(object({
+      name            = string
+      vcpu_count      = number
+      memory_bytes    = number
+      deletion_policy = optional(string, "PREVENT")
+      labels          = optional(map(string), {})
+      rebalance_mode  = optional(string, "AUTO_REBALANCE_ON_SCALE_UP")
+      connected_subnets = list(object({
+        subnet                   = string
+        project_id               = optional(string)
+        grant_service_agent_role = optional(bool, true)
+      }))
+      client_principals = optional(list(string), [])
+      topics = optional(list(object({
+        name               = string
+        partition_count    = optional(number)
+        replication_factor = optional(number, 3)
+        configs            = optional(map(string), {})
+        deletion_policy    = optional(string, "PREVENT")
+      })), [])
+      acls = optional(list(object({
+        id              = string
+        deletion_policy = optional(string, "PREVENT")
+        entries = list(object({
+          principal       = string
+          operation       = string
+          permission_type = optional(string, "ALLOW")
+          host            = optional(string, "*")
+        }))
+      })), [])
+    })), [])
+  })
+}

--- a/infra/kafka/skeleton/infrastructure/code/modules/kafka/versions.tf
+++ b/infra/kafka/skeleton/infrastructure/code/modules/kafka/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+    google-beta = {
+      source = "hashicorp/google-beta"
+    }
+  }
+}

--- a/infra/kafka/skeleton/infrastructure/code/terragrunt.hcl
+++ b/infra/kafka/skeleton/infrastructure/code/terragrunt.hcl
@@ -1,0 +1,50 @@
+terraform_binary             = "tofu"
+terraform_version_constraint = ">= 1.12.3"
+
+locals {
+  yaml_common = try(yamldecode(file("../common.yaml")), {})
+  yaml_config = try(yamldecode(file("../config.yaml")), {})
+  config      = merge(local.yaml_common, local.yaml_config)
+  p2p_version = get_env("P2P_VERSION")
+  environment = get_env("environment")
+  tenant_name = get_env("tenant_name")
+  app_name    = get_env("app_name")
+
+  # Check if required configuration is present
+  has_required_config = alltrue([
+    can(local.config.region),
+    can(local.config.infrastructure_project_id),
+    can(local.config.platform_project_id)
+  ])
+}
+
+# Skip execution if required configuration is missing
+skip = !local.has_required_config
+
+inputs = {
+  p2p_version               = local.p2p_version
+  region                    = try(local.config.region, null)
+  infrastructure_project_id = try(local.config.infrastructure_project_id, null)
+  platform_project_id       = try(local.config.platform_project_id, null)
+  environment               = local.environment
+  kafka = try(local.config.kafka, {
+    enabled  = false
+    clusters = []
+  })
+}
+
+remote_state {
+  backend = "gcs"
+
+  config = {
+    project                   = try(local.config.infrastructure_project_id, null)
+    location                  = try(local.config.region, null)
+    bucket                    = "tfstate-${try(local.config.infrastructure_project_id, "")}"
+    prefix                    = "${try(local.config.infrastructure_project_id, "")}/environments/${local.environment}/tenants/${local.tenant_name}/${local.app_name}/terraform/state"
+    enable_bucket_policy_only = true
+    gcs_bucket_labels = {
+      owner = "terragrunt"
+      name  = "terraform_state"
+    }
+  }
+}

--- a/infra/kafka/skeleton/infrastructure/code/variables.tf
+++ b/infra/kafka/skeleton/infrastructure/code/variables.tf
@@ -1,0 +1,24 @@
+variable "p2p_version" {
+  type        = string
+  description = "Version"
+}
+
+variable "infrastructure_project_id" {
+  type        = string
+  description = "Project ID where Kafka resources are created"
+}
+
+variable "platform_project_id" {
+  type        = string
+  description = "Core Project ID where K8s is. You get this from Platform Environments repo"
+}
+
+variable "environment" {
+  type        = string
+  description = "Application environment name (eg functional)"
+}
+
+variable "region" {
+  type        = string
+  description = "Region name"
+}

--- a/infra/kafka/skeleton/infrastructure/code/versions.tf
+++ b/infra/kafka/skeleton/infrastructure/code/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.12.3"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "7.37.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "7.37.0"
+    }
+  }
+}

--- a/infra/kafka/skeleton/p2p/config/.yamllint
+++ b/infra/kafka/skeleton/p2p/config/.yamllint
@@ -1,0 +1,6 @@
+---
+extends: default
+
+rules:
+  line-length:
+    max: 512

--- a/infra/kafka/skeleton/p2p/config/common.yaml
+++ b/infra/kafka/skeleton/p2p/config/common.yaml
@@ -1,0 +1,34 @@
+---
+region: europe-west2
+
+kafka:
+  enabled: true
+  clusters:
+    - name: my-app
+      vcpu_count: 3
+      memory_bytes: 3221225472
+      connected_subnets:
+        - project_id: core-platform-dev
+          subnet: projects/core-platform-dev/regions/europe-west2/subnetworks/gke-workloads
+          grant_service_agent_role: true
+      client_principals:
+        - serviceAccount:my-app-ca@core-platform-dev.iam.gserviceaccount.com
+      topics:
+        - name: events
+          partition_count: 3
+          replication_factor: 3
+          configs:
+            cleanup.policy: delete
+      acls:
+        - id: topic/events
+          entries:
+            - principal: User:my-app-ca@core-platform-dev.iam.gserviceaccount.com
+              operation: ALL
+              permission_type: ALLOW
+              host: "*"
+        - id: consumerGroup/my-app
+          entries:
+            - principal: User:my-app-ca@core-platform-dev.iam.gserviceaccount.com
+              operation: ALL
+              permission_type: ALLOW
+              host: "*"

--- a/infra/kafka/skeleton/p2p/config/extended-test.yaml
+++ b/infra/kafka/skeleton/p2p/config/extended-test.yaml
@@ -1,0 +1,3 @@
+---
+# infrastructure_project_id:
+# platform_project_id:

--- a/infra/kafka/skeleton/p2p/config/functional.yaml
+++ b/infra/kafka/skeleton/p2p/config/functional.yaml
@@ -1,0 +1,3 @@
+---
+# infrastructure_project_id:
+# platform_project_id:

--- a/infra/kafka/skeleton/p2p/config/integration.yaml
+++ b/infra/kafka/skeleton/p2p/config/integration.yaml
@@ -1,0 +1,3 @@
+---
+# infrastructure_project_id:
+# platform_project_id:

--- a/infra/kafka/skeleton/p2p/config/nft.yaml
+++ b/infra/kafka/skeleton/p2p/config/nft.yaml
@@ -1,0 +1,3 @@
+---
+# infrastructure_project_id:
+# platform_project_id:

--- a/infra/kafka/skeleton/p2p/config/prod.yaml
+++ b/infra/kafka/skeleton/p2p/config/prod.yaml
@@ -1,0 +1,3 @@
+---
+# infrastructure_project_id:
+# platform_project_id:

--- a/infra/kafka/template.yaml
+++ b/infra/kafka/template.yaml
@@ -1,0 +1,5 @@
+---
+name: infra-kafka
+description: Infra Kafka application
+kind: infra
+skeletonPath: ./skeleton


### PR DESCRIPTION
## Summary
- add a new infra/kafka template for GCP Managed Service for Apache Kafka
- configure Managed Kafka clusters with platform connected subnets, service-agent IAM grants, client IAM grants, topics, and Kafka ACLs
- include a temporary sample kafka config in common.yaml for testing

## Validation
- tofu -chdir=infra/kafka/skeleton/infrastructure/code fmt -check -diff -recursive
- terragrunt hcl fmt --check --working-dir infra/kafka/skeleton/infrastructure/code
- tofu -chdir=infra/kafka/skeleton/infrastructure/code init -backend=false
- tofu -chdir=infra/kafka/skeleton/infrastructure/code validate
- docker run --rm --mount type=bind,source=./infra/kafka/skeleton/p2p/config,target=/data docker.io/cytopia/yamllint -s .
- docker run --rm -i docker.io/hadolint/hadolint < infra/kafka/skeleton/Dockerfile
- docker build -t infra-kafka-template-test infra/kafka/skeleton

## Notes
- The sample config is intentionally temporary and should be replaced with docs before merge.
- Stage project IDs remain commented so provisioning is skipped until explicitly configured.