### PR TITLE
Pin java template perl-base security update

### DIFF
--- a/java/web/skeleton/Dockerfile
+++ b/java/web/skeleton/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update \
   libsystemd0=255.4-1ubuntu8.16 \
   libudev1=255.4-1ubuntu8.16 \
   openssl=3.0.13-0ubuntu3.11 \
+  perl-base=5.38.2-3.2ubuntu0.3 \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary

Pins the Java web template runtime image to `perl-base=5.38.2-3.2ubuntu0.3` so newly rendered Java reference applications include the Ubuntu Noble security update.


