### PR TITLE
Add Prometheus metrics out of the box to the Next.js templates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -279,7 +279,7 @@ Each template exposes different ports and health endpoints:
 |---|---|---|---|
 | `go/web`, `python/web` | `-p 8080:8080 -p 8081:8081` | 3s | `:8080/hello` → "Hello world"; `:8081/internal/status`; `:8081/metrics` |
 | `java/web` | `-p 8080:8080 -p 8081:8081` | 8s | `:8080/hello` → "Hello World!"; `:8081/health` → `{"status":"UP"}`; `:8081/prometheus` |
-| `nextjs/web`, `static/nextra` | `-p 3000:3000` | 5s | `:3000/readyz` → "OK"; `:3000/livez` → "OK" |
+| `nextjs/web`, `static/nextra` | `-p 3000:3000 -p 8081:8081` | 5s | `:3000/readyz` → "OK"; `:3000/livez` → "OK"; `:8081/metrics` (Prometheus exposition) |
 | `docker/web` | `-p 9898:9898` | 2s | `:9898/healthz` → `{"status":"OK"}`; `:9898/readyz` → `{"status":"OK"}` |
 
 ```bash

--- a/nextjs/web/skeleton/Dockerfile
+++ b/nextjs/web/skeleton/Dockerfile
@@ -41,6 +41,7 @@ COPY --from=build --chown=nextjs:nodejs /app/.next/static ./.next/static
 USER nextjs
 
 EXPOSE 3000
+EXPOSE 8081
 
 ENV PORT=3000
 ENV HOSTNAME="0.0.0.0"

--- a/nextjs/web/skeleton/Makefile
+++ b/nextjs/web/skeleton/Makefile
@@ -88,7 +88,7 @@ deploy-%:
 
 .PHONY: run-app
 run-app: ## Run app
-	docker run --rm -p 3000:3000 --name "$(p2p_app_name)" "$(p2p_image_tag)"
+	docker run --rm -p 3000:3000 -p 8081:8081 --name "$(p2p_app_name)" "$(p2p_image_tag)"
 
 .PHONY: run-functional
 run-functional:

--- a/nextjs/web/skeleton/next.config.ts
+++ b/nextjs/web/skeleton/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: "standalone",
+  serverExternalPackages: ["prom-client"],
 };
 
 export default nextConfig;

--- a/nextjs/web/skeleton/p2p/config/common.yaml
+++ b/nextjs/web/skeleton/p2p/config/common.yaml
@@ -54,3 +54,7 @@ ingress:
 
 service:
   port: 3000
+
+metrics:
+  enabled: true
+  port: 8081

--- a/nextjs/web/skeleton/package.json
+++ b/nextjs/web/skeleton/package.json
@@ -18,6 +18,7 @@
     "lucide-react": "^1.21.0",
     "next": "16.2.9",
     "next-themes": "^0.4.6",
+    "prom-client": "^15.1.3",
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "tailwind-merge": "^3.6.0"

--- a/nextjs/web/skeleton/src/instrumentation.ts
+++ b/nextjs/web/skeleton/src/instrumentation.ts
@@ -1,0 +1,22 @@
+import type { Instrumentation } from "next";
+
+export async function register(): Promise<void> {
+  if (process.env.NEXT_RUNTIME === "nodejs") {
+    await import("./lib/metrics");
+
+    const { startMetricsServer } = await import("./lib/metrics-server");
+    startMetricsServer(Number(process.env.METRICS_PORT) || 8081);
+  }
+}
+
+export const onRequestError: Instrumentation.onRequestError = async (
+  _error,
+  _request,
+  context,
+) => {
+  if (process.env.NEXT_RUNTIME !== "nodejs") {
+    return;
+  }
+  const { recordServerError } = await import("./lib/metrics");
+  recordServerError(context.routeType, context.routePath);
+};

--- a/nextjs/web/skeleton/src/lib/__tests__/metrics-server.test.ts
+++ b/nextjs/web/skeleton/src/lib/__tests__/metrics-server.test.ts
@@ -52,4 +52,18 @@ describe("metrics server", () => {
       server.close();
     }
   });
+
+  it("exits the process when the port cannot be bound", async () => {
+    const blocker = startMetricsServer(0);
+    const port = await listen(blocker);
+    const exitSpy = jest
+      .spyOn(process, "exit")
+      .mockImplementation(() => undefined as never);
+    await new Promise<void>((resolve) => {
+      startMetricsServer(port).on("error", () => resolve());
+    });
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+    blocker.close();
+  });
 });

--- a/nextjs/web/skeleton/src/lib/__tests__/metrics-server.test.ts
+++ b/nextjs/web/skeleton/src/lib/__tests__/metrics-server.test.ts
@@ -1,0 +1,55 @@
+/**
+ * @jest-environment node
+ */
+import { get } from "node:http";
+import type { AddressInfo } from "node:net";
+import { startMetricsServer } from "../metrics-server";
+
+function request(
+  port: number,
+  path: string,
+): Promise<{ status: number; contentType?: string; body: string }> {
+  return new Promise((resolve, reject) => {
+    get({ host: "127.0.0.1", port, path }, (res) => {
+      let body = "";
+      res.on("data", (chunk) => (body += chunk));
+      res.on("end", () =>
+        resolve({
+          status: res.statusCode ?? 0,
+          contentType: res.headers["content-type"],
+          body,
+        }),
+      );
+    }).on("error", reject);
+  });
+}
+
+async function listen(server: ReturnType<typeof startMetricsServer>) {
+  await new Promise<void>((resolve) => server.once("listening", resolve));
+  return (server.address() as AddressInfo).port;
+}
+
+describe("metrics server", () => {
+  it("serves Prometheus exposition on /metrics", async () => {
+    const server = startMetricsServer(0);
+    try {
+      const res = await request(await listen(server), "/metrics");
+      expect(res.status).toBe(200);
+      expect(res.contentType).toContain("text/plain");
+      expect(res.body).toContain("nodejs_eventloop_lag_seconds");
+      expect(res.body).toContain("nextjs_build_info");
+    } finally {
+      server.close();
+    }
+  });
+
+  it("returns 404 for other paths", async () => {
+    const server = startMetricsServer(0);
+    try {
+      const res = await request(await listen(server), "/other");
+      expect(res.status).toBe(404);
+    } finally {
+      server.close();
+    }
+  });
+});

--- a/nextjs/web/skeleton/src/lib/metrics-server.ts
+++ b/nextjs/web/skeleton/src/lib/metrics-server.ts
@@ -17,7 +17,8 @@ export function startMetricsServer(port: number): Server {
       });
   });
   server.on("error", (err) => {
-    console.error("metrics server error:", err);
+    console.error("metrics server failed to start:", err);
+    process.exit(1);
   });
   server.listen(port, "0.0.0.0");
   return server;

--- a/nextjs/web/skeleton/src/lib/metrics-server.ts
+++ b/nextjs/web/skeleton/src/lib/metrics-server.ts
@@ -1,0 +1,24 @@
+import { createServer, type Server } from "node:http";
+import { registry } from "./metrics";
+
+export function startMetricsServer(port: number): Server {
+  const server = createServer((req, res) => {
+    if (req.method !== "GET" || req.url !== "/metrics") {
+      res.writeHead(404).end("Not Found");
+      return;
+    }
+    registry
+      .metrics()
+      .then((body) => {
+        res.writeHead(200, { "Content-Type": registry.contentType }).end(body);
+      })
+      .catch(() => {
+        res.writeHead(500).end("Internal Server Error");
+      });
+  });
+  server.on("error", (err) => {
+    console.error("metrics server error:", err);
+  });
+  server.listen(port, "0.0.0.0");
+  return server;
+}

--- a/nextjs/web/skeleton/src/lib/metrics.ts
+++ b/nextjs/web/skeleton/src/lib/metrics.ts
@@ -1,0 +1,42 @@
+import { Counter, Gauge, Registry, collectDefaultMetrics } from "prom-client";
+
+type Metrics = {
+  registry: Registry;
+  serverErrors: Counter<"route_type" | "route">;
+};
+
+const globalForMetrics = globalThis as typeof globalThis & {
+  __appMetrics?: Metrics;
+};
+
+function createMetrics(): Metrics {
+  const registry = new Registry();
+  collectDefaultMetrics({ register: registry });
+
+  const serverErrors = new Counter({
+    name: "nextjs_server_errors_total",
+    help: "Total server-side errors captured by the onRequestError hook.",
+    labelNames: ["route_type", "route"],
+    registers: [registry],
+  });
+
+  const buildInfo = new Gauge({
+    name: "nextjs_build_info",
+    help: "Build and runtime information for the server.",
+    labelNames: ["node_version"],
+    registers: [registry],
+  });
+  buildInfo.set({ node_version: process.version }, 1);
+
+  return { registry, serverErrors };
+}
+
+const metrics = globalForMetrics.__appMetrics ?? createMetrics();
+globalForMetrics.__appMetrics = metrics;
+
+export const registry = metrics.registry;
+export const serverErrors = metrics.serverErrors;
+
+export function recordServerError(routeType: string, route: string): void {
+  serverErrors.inc({ route_type: routeType, route: route || "unknown" });
+}

--- a/nextjs/web/skeleton/yarn.lock
+++ b/nextjs/web/skeleton/yarn.lock
@@ -1030,6 +1030,11 @@
   resolved "https://registry.yarnpkg.com/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz#3dc35ba0f1e66b403c00b39344f870298ebb1c8e"
   integrity sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==
 
+"@opentelemetry/api@^1.4.0":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.9.1.tgz#c1b0346de336ba55af2d5a7970882037baedec05"
+  integrity sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==
+
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
@@ -2097,6 +2102,11 @@ baseline-browser-mapping@^2.10.38, baseline-browser-mapping@^2.9.19:
   version "2.10.38"
   resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz#c84d093c4bf7325c5053c279d90f153c66526042"
   integrity sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==
+
+bintrees@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/bintrees/-/bintrees-1.0.2.tgz#49f896d6e858a4a499df85c38fb399b9aff840f8"
+  integrity sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==
 
 brace-expansion@^5.0.2:
   version "5.0.6"
@@ -4636,6 +4646,14 @@ pretty-format@^27.0.2:
     ansi-styles "^5.0.0"
     react-is "^17.0.1"
 
+prom-client@^15.1.3:
+  version "15.1.3"
+  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-15.1.3.tgz#69fa8de93a88bc9783173db5f758dc1c69fa8fc2"
+  integrity sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==
+  dependencies:
+    "@opentelemetry/api" "^1.4.0"
+    tdigest "^0.1.1"
+
 prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
@@ -5238,6 +5256,13 @@ tapable@^2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.3.3.tgz#5da7c9992c46038221267985ab28421a8879f160"
   integrity sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==
+
+tdigest@^0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/tdigest/-/tdigest-0.1.2.tgz#96c64bac4ff10746b910b0e23b515794e12faced"
+  integrity sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==
+  dependencies:
+    bintrees "1.0.2"
 
 test-exclude@^6.0.0:
   version "6.0.0"

--- a/static/nextra/skeleton/Dockerfile
+++ b/static/nextra/skeleton/Dockerfile
@@ -41,6 +41,7 @@ COPY --from=build --chown=nextjs:nodejs /app/.next/static ./.next/static
 USER nextjs
 
 EXPOSE 3000
+EXPOSE 8081
 
 ENV PORT=3000
 ENV HOSTNAME="0.0.0.0"

--- a/static/nextra/skeleton/Makefile
+++ b/static/nextra/skeleton/Makefile
@@ -88,7 +88,7 @@ deploy-%:
 
 .PHONY: run-app
 run-app: ## Run app
-	docker run --rm -p 3000:3000 --name "$(p2p_app_name)" "$(p2p_image_tag)"
+	docker run --rm -p 3000:3000 -p 8081:8081 --name "$(p2p_app_name)" "$(p2p_image_tag)"
 
 .PHONY: run-functional
 run-functional:

--- a/static/nextra/skeleton/next.config.ts
+++ b/static/nextra/skeleton/next.config.ts
@@ -7,4 +7,5 @@ const withNextra = nextra({
 
 export default withNextra({
   output: "standalone",
+  serverExternalPackages: ["prom-client"],
 });

--- a/static/nextra/skeleton/p2p/config/common.yaml
+++ b/static/nextra/skeleton/p2p/config/common.yaml
@@ -54,3 +54,7 @@ ingress:
 
 service:
   port: 3000
+
+metrics:
+  enabled: true
+  port: 8081

--- a/static/nextra/skeleton/package.json
+++ b/static/nextra/skeleton/package.json
@@ -15,6 +15,7 @@
     "next": "16.2.9",
     "nextra": "4.6.0",
     "nextra-theme-docs": "4.6.0",
+    "prom-client": "^15.1.3",
     "react": "19.2.7",
     "react-dom": "19.2.7"
   },

--- a/static/nextra/skeleton/src/instrumentation.ts
+++ b/static/nextra/skeleton/src/instrumentation.ts
@@ -1,0 +1,22 @@
+import type { Instrumentation } from "next";
+
+export async function register(): Promise<void> {
+  if (process.env.NEXT_RUNTIME === "nodejs") {
+    await import("./lib/metrics");
+
+    const { startMetricsServer } = await import("./lib/metrics-server");
+    startMetricsServer(Number(process.env.METRICS_PORT) || 8081);
+  }
+}
+
+export const onRequestError: Instrumentation.onRequestError = async (
+  _error,
+  _request,
+  context,
+) => {
+  if (process.env.NEXT_RUNTIME !== "nodejs") {
+    return;
+  }
+  const { recordServerError } = await import("./lib/metrics");
+  recordServerError(context.routeType, context.routePath);
+};

--- a/static/nextra/skeleton/src/lib/__tests__/metrics-server.test.ts
+++ b/static/nextra/skeleton/src/lib/__tests__/metrics-server.test.ts
@@ -52,4 +52,18 @@ describe("metrics server", () => {
       server.close();
     }
   });
+
+  it("exits the process when the port cannot be bound", async () => {
+    const blocker = startMetricsServer(0);
+    const port = await listen(blocker);
+    const exitSpy = jest
+      .spyOn(process, "exit")
+      .mockImplementation(() => undefined as never);
+    await new Promise<void>((resolve) => {
+      startMetricsServer(port).on("error", () => resolve());
+    });
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+    blocker.close();
+  });
 });

--- a/static/nextra/skeleton/src/lib/__tests__/metrics-server.test.ts
+++ b/static/nextra/skeleton/src/lib/__tests__/metrics-server.test.ts
@@ -1,0 +1,55 @@
+/**
+ * @jest-environment node
+ */
+import { get } from "node:http";
+import type { AddressInfo } from "node:net";
+import { startMetricsServer } from "../metrics-server";
+
+function request(
+  port: number,
+  path: string,
+): Promise<{ status: number; contentType?: string; body: string }> {
+  return new Promise((resolve, reject) => {
+    get({ host: "127.0.0.1", port, path }, (res) => {
+      let body = "";
+      res.on("data", (chunk) => (body += chunk));
+      res.on("end", () =>
+        resolve({
+          status: res.statusCode ?? 0,
+          contentType: res.headers["content-type"],
+          body,
+        }),
+      );
+    }).on("error", reject);
+  });
+}
+
+async function listen(server: ReturnType<typeof startMetricsServer>) {
+  await new Promise<void>((resolve) => server.once("listening", resolve));
+  return (server.address() as AddressInfo).port;
+}
+
+describe("metrics server", () => {
+  it("serves Prometheus exposition on /metrics", async () => {
+    const server = startMetricsServer(0);
+    try {
+      const res = await request(await listen(server), "/metrics");
+      expect(res.status).toBe(200);
+      expect(res.contentType).toContain("text/plain");
+      expect(res.body).toContain("nodejs_eventloop_lag_seconds");
+      expect(res.body).toContain("nextjs_build_info");
+    } finally {
+      server.close();
+    }
+  });
+
+  it("returns 404 for other paths", async () => {
+    const server = startMetricsServer(0);
+    try {
+      const res = await request(await listen(server), "/other");
+      expect(res.status).toBe(404);
+    } finally {
+      server.close();
+    }
+  });
+});

--- a/static/nextra/skeleton/src/lib/metrics-server.ts
+++ b/static/nextra/skeleton/src/lib/metrics-server.ts
@@ -17,7 +17,8 @@ export function startMetricsServer(port: number): Server {
       });
   });
   server.on("error", (err) => {
-    console.error("metrics server error:", err);
+    console.error("metrics server failed to start:", err);
+    process.exit(1);
   });
   server.listen(port, "0.0.0.0");
   return server;

--- a/static/nextra/skeleton/src/lib/metrics-server.ts
+++ b/static/nextra/skeleton/src/lib/metrics-server.ts
@@ -1,0 +1,24 @@
+import { createServer, type Server } from "node:http";
+import { registry } from "./metrics";
+
+export function startMetricsServer(port: number): Server {
+  const server = createServer((req, res) => {
+    if (req.method !== "GET" || req.url !== "/metrics") {
+      res.writeHead(404).end("Not Found");
+      return;
+    }
+    registry
+      .metrics()
+      .then((body) => {
+        res.writeHead(200, { "Content-Type": registry.contentType }).end(body);
+      })
+      .catch(() => {
+        res.writeHead(500).end("Internal Server Error");
+      });
+  });
+  server.on("error", (err) => {
+    console.error("metrics server error:", err);
+  });
+  server.listen(port, "0.0.0.0");
+  return server;
+}

--- a/static/nextra/skeleton/src/lib/metrics.ts
+++ b/static/nextra/skeleton/src/lib/metrics.ts
@@ -1,0 +1,42 @@
+import { Counter, Gauge, Registry, collectDefaultMetrics } from "prom-client";
+
+type Metrics = {
+  registry: Registry;
+  serverErrors: Counter<"route_type" | "route">;
+};
+
+const globalForMetrics = globalThis as typeof globalThis & {
+  __appMetrics?: Metrics;
+};
+
+function createMetrics(): Metrics {
+  const registry = new Registry();
+  collectDefaultMetrics({ register: registry });
+
+  const serverErrors = new Counter({
+    name: "nextjs_server_errors_total",
+    help: "Total server-side errors captured by the onRequestError hook.",
+    labelNames: ["route_type", "route"],
+    registers: [registry],
+  });
+
+  const buildInfo = new Gauge({
+    name: "nextjs_build_info",
+    help: "Build and runtime information for the server.",
+    labelNames: ["node_version"],
+    registers: [registry],
+  });
+  buildInfo.set({ node_version: process.version }, 1);
+
+  return { registry, serverErrors };
+}
+
+const metrics = globalForMetrics.__appMetrics ?? createMetrics();
+globalForMetrics.__appMetrics = metrics;
+
+export const registry = metrics.registry;
+export const serverErrors = metrics.serverErrors;
+
+export function recordServerError(routeType: string, route: string): void {
+  serverErrors.inc({ route_type: routeType, route: route || "unknown" });
+}

--- a/static/nextra/skeleton/yarn.lock
+++ b/static/nextra/skeleton/yarn.lock
@@ -1244,6 +1244,11 @@
   resolved "https://registry.yarnpkg.com/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz#3dc35ba0f1e66b403c00b39344f870298ebb1c8e"
   integrity sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==
 
+"@opentelemetry/api@^1.4.0":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.9.1.tgz#c1b0346de336ba55af2d5a7970882037baedec05"
+  integrity sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==
+
 "@pagefind/darwin-arm64@1.5.2":
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/@pagefind/darwin-arm64/-/darwin-arm64-1.5.2.tgz#965152ffc22bccd8299e065f7cfbc6869a1bffe0"
@@ -2590,6 +2595,11 @@ better-react-mathjax@^2.3.0:
   integrity sha512-K0ceQC+jQmB+NLDogO5HCpqmYf18AU2FxDbLdduYgkHYWZApFggkHE4dIaXCV1NqeoscESYXXo1GSkY6fA295w==
   dependencies:
     mathjax-full "^3.2.2"
+
+bintrees@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/bintrees/-/bintrees-1.0.2.tgz#49f896d6e858a4a499df85c38fb399b9aff840f8"
+  integrity sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==
 
 brace-expansion@^5.0.2:
   version "5.0.6"
@@ -6839,6 +6849,14 @@ pretty-format@^27.0.2:
     ansi-styles "^5.0.0"
     react-is "^17.0.1"
 
+prom-client@^15.1.3:
+  version "15.1.3"
+  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-15.1.3.tgz#69fa8de93a88bc9783173db5f758dc1c69fa8fc2"
+  integrity sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==
+  dependencies:
+    "@opentelemetry/api" "^1.4.0"
+    tdigest "^0.1.1"
+
 prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
@@ -7806,6 +7824,13 @@ tapable@^2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.3.3.tgz#5da7c9992c46038221267985ab28421a8879f160"
   integrity sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==
+
+tdigest@^0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/tdigest/-/tdigest-0.1.2.tgz#96c64bac4ff10746b910b0e23b515794e12faced"
+  integrity sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==
+  dependencies:
+    bintrees "1.0.2"
 
 test-exclude@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
## What

`nextjs/web` and `static/nextra` had no metrics (only `/livez`,`/readyz` on 3000), unlike java/go/python which expose Prometheus metrics on the internal ops port 8081. This brings both Next.js templates to the repo's two-port convention so apps scaffolded from them get **metrics out of the box**.

## Approach: lightweight (matches go), not full OpenTelemetry

Java/Python get request metrics cheaply from framework-native middleware (Micrometer / prometheus_fastapi_instrumentator). Next.js has no equivalent low-overhead option — the only way to capture all-request metrics is the OpenTelemetry span bridge, which is exactly the *"per-request middleware with significant overhead"* `AGENTS.md` tells templates to avoid (NFT-gated).

So this follows **go's pattern**: prom-client **default Node.js metrics** (heap, event-loop lag, GC, CPU, process) + `nextjs_build_info` + a `nextjs_server_errors_total` counter (via `onRequestError`). No per-request tracing. Request RED metrics stay an opt-in per app.

## Changes (identical for both templates)

- `src/lib/metrics.ts`, `src/lib/metrics-server.ts`, `src/instrumentation.ts` — registry + a dedicated metrics HTTP server on **8081** (`/metrics`, bound `0.0.0.0`) started from the instrumentation hook.
- `next.config.ts` (`serverExternalPackages: ["prom-client"]`), `Dockerfile` (`EXPOSE 8081`), `package.json` (`prom-client`), a metrics-server Jest test.
- `p2p/config/common.yaml` — `metrics: { enabled: true, port: 8081 }`, matching java/go.
- `AGENTS.md` smoke-test table updated (`-p 8081:8081`, `:8081/metrics`).

## Verification

- Build, Jest, and `yarn --frozen-lockfile` green for both templates.
- Standalone `node server.js` (the container's CMD) serves `/metrics` on 8081 (200, `nextjs_build_info` + default Node metrics) and **404 on the app port** — both templates.
- Docker image builds clean.
- `helm template` confirms the chart wires it end-to-end: ServiceMonitor `port: metrics, path: /metrics` → Service `metrics:8081` → containerPort `metrics:8081`. No dangling ServiceMonitor.

## ⚠️ Note for reviewers

The lightweight design was chosen specifically to be **NFT-safe**, but the K6 NFT stage has **not** been load-tested on a cluster. Recommend watching the NFT stage on the first real app scaffolded from each template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
