### PR TITLE
Add agent worktree guidance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea/
+.worktrees/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,10 @@
 # AGENTS.md — Core Platform Software Templates
 
+## Branching and worktrees
+
+- Use a git worktree under `.worktrees/` for all changes; do not work directly on `main`.
+- Before committing, run `git status` or `git branch --show-current` and confirm you are not on `main`.
+
 ## Repository layout
 
 ```


### PR DESCRIPTION
## Summary
- Add instructions to AGENTS.md to use git worktrees under .worktrees/.
- Ignore local .worktrees/ directories.

## Test Plan
- Verified .worktrees/ is ignored with git check-ignore.
- Verified AGENTS.md contains worktree guidance.