### PR TITLE
Adopt P2P PR integration default

### DIFF
--- a/docker/web/skeleton/.github/workflows/fast-feedback.yaml
+++ b/docker/web/skeleton/.github/workflows/fast-feedback.yaml
@@ -41,7 +41,6 @@ jobs:
       app-name: {{ name }}
       tenant-name: {{ tenant }}
       version: {% raw %}${{ needs.version.outputs.version }}{% endraw %}
-      skip-fastfeedback-integration-on-prs: true
 {%- if working_directory is defined and working_directory %}
       working-directory: {{ working_directory }}
 {%- endif %}

--- a/go/web/skeleton/.github/workflows/fast-feedback.yaml
+++ b/go/web/skeleton/.github/workflows/fast-feedback.yaml
@@ -41,7 +41,6 @@ jobs:
       app-name: {{ name }}
       tenant-name: {{ tenant }}
       version: {% raw %}${{ needs.version.outputs.version }}{% endraw %}
-      skip-fastfeedback-integration-on-prs: true
 {%- if working_directory is defined and working_directory %}
       working-directory: {{ working_directory }}
 {%- endif %}

--- a/java/web/skeleton/.github/workflows/fast-feedback.yaml
+++ b/java/web/skeleton/.github/workflows/fast-feedback.yaml
@@ -41,7 +41,6 @@ jobs:
       app-name: {{ name }}
       tenant-name: {{ tenant }}
       version: {% raw %}${{ needs.version.outputs.version }}{% endraw %}
-      skip-fastfeedback-integration-on-prs: true
 {%- if working_directory is defined and working_directory %}
       working-directory: {{ working_directory }}
 {%- endif %}

--- a/monitoring-stack/skeleton/.github/workflows/fast-feedback.yaml
+++ b/monitoring-stack/skeleton/.github/workflows/fast-feedback.yaml
@@ -41,7 +41,6 @@ jobs:
       app-name: {{ name }}
       tenant-name: {{ tenant }}
       version: {% raw %}${{ needs.version.outputs.version }}{% endraw %}
-      skip-fastfeedback-integration-on-prs: true
 {%- if working_directory is defined and working_directory %}
       working-directory: {{ working_directory }}
 {%- endif %}

--- a/nextjs/web/skeleton/.github/workflows/fast-feedback.yaml
+++ b/nextjs/web/skeleton/.github/workflows/fast-feedback.yaml
@@ -41,7 +41,6 @@ jobs:
       app-name: {{ name }}
       tenant-name: {{ tenant }}
       version: {% raw %}${{ needs.version.outputs.version }}{% endraw %}
-      skip-fastfeedback-integration-on-prs: true
 {%- if working_directory is defined and working_directory %}
       working-directory: {{ working_directory }}
 {%- endif %}

--- a/python/web/skeleton/.github/workflows/fast-feedback.yaml
+++ b/python/web/skeleton/.github/workflows/fast-feedback.yaml
@@ -41,7 +41,6 @@ jobs:
       app-name: {{ name }}
       tenant-name: {{ tenant }}
       version: {% raw %}${{ needs.version.outputs.version }}{% endraw %}
-      skip-fastfeedback-integration-on-prs: true
 {%- if working_directory is defined and working_directory %}
       working-directory: {{ working_directory }}
 {%- endif %}

--- a/static/nextra/skeleton/.github/workflows/fast-feedback.yaml
+++ b/static/nextra/skeleton/.github/workflows/fast-feedback.yaml
@@ -41,7 +41,6 @@ jobs:
       app-name: {{ name }}
       tenant-name: {{ tenant }}
       version: {% raw %}${{ needs.version.outputs.version }}{% endraw %}
-      skip-fastfeedback-integration-on-prs: true
 {%- if working_directory is defined and working_directory %}
       working-directory: {{ working_directory }}
 {%- endif %}


### PR DESCRIPTION
## Summary
- remove obsolete skip-fastfeedback-integration-on-prs inputs from app template fast-feedback workflows
- rely on the new P2P default that skips integration tests on pull requests unless explicitly opted in

## Validation
- make templates-validate
- git diff --check