### PR TITLE
Add generated AGENTS.md guidance to app templates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,3 +33,4 @@ templates-validate:
 		echo "Template validation tests passed" ; \
 	fi ; \
 	exit "$${ERRVAL}"
+	@bash tests/template_docs_test.sh

--- a/docker/web/skeleton/AGENTS.md
+++ b/docker/web/skeleton/AGENTS.md
@@ -1,0 +1,45 @@
+# AGENTS.md - {{ name }}
+
+## Template And Tech Stack
+
+This repository was generated from the Core Platform `docker-web` software template. It is a generic Docker web application based on the `podinfo` reference image, serves traffic on port `9898`, and deploys with the `core-platform-assets/core-platform-app` Helm chart.
+
+## Core Platform P2P
+
+Core Platform Path to Production (P2P) is driven by GitHub Actions workflows in `.github/workflows/` and Make targets in `Makefile`. The workflows delegate to reusable workflows from `coreeng/p2p` and the Makefile downloads `p2p.mk` from the same versioned P2P contract.
+
+### Workflows
+
+- `fast-feedback.yaml` runs on pushes, pull requests, and manual dispatch. It creates a version, builds the app image, deploys the functional stage, and runs functional checks.
+- `extended-test.yaml` runs on schedule or manual dispatch. It finds the latest extended-test candidate image and runs the extended-test workflow.
+- `prod.yaml` runs on schedule or manual dispatch. It finds the latest production candidate image and deploys production.
+- `scheduled-security-scan.yaml` runs the generated repository's scheduled security scan.
+
+### Stages
+
+- Build creates and pushes the application image using the version produced by P2P.
+- Functional deploys the app to the functional namespace and runs functional tests as Helm tests.
+- Non-functional tests deploy the app to the NFT namespace and run K6 load tests as Helm tests when the NFT target is enabled.
+- Integration deploys the app to the integration namespace and runs integration tests as Helm tests.
+- Extended tests deploy the promoted image to the extended-test namespace and run longer-running validation.
+- Prod deploys the selected production candidate to the production namespace.
+
+### Configuration
+
+- `p2p/config/common.yaml` contains Helm values shared by all stages. It is rendered with environment variables before Helm receives it.
+- `p2p/config/functional.yaml` contains functional-stage overrides.
+- `p2p/config/nft.yaml` contains NFT-stage overrides.
+- `p2p/config/integration.yaml` contains integration-stage overrides.
+- `p2p/config/extended-test.yaml` contains extended-test-stage overrides.
+- `p2p/config/prod.yaml` contains production overrides.
+- Stage-specific files should only contain differences from `common.yaml`.
+
+### Tests
+
+- Unit and lint checks run before the app image is built.
+- Functional tests live in `p2p/tests/functional/` and validate externally visible app behavior.
+- Non-functional tests live in `p2p/tests/nft/` and use K6 plus Prometheus validation for load-test thresholds.
+- Integration tests live in `p2p/tests/integration/` and validate behavior against deployed dependencies.
+- Extended tests live in `p2p/tests/extended/` and are intended for longer or higher-load validation than fast feedback.
+
+Keep generated P2P contract changes aligned across `Makefile`, `.github/workflows/`, `p2p/config/`, and `p2p/tests/`.

--- a/docker/web/skeleton/README.md
+++ b/docker/web/skeleton/README.md
@@ -1,139 +1,20 @@
 # {{ name }}
 
-Docker web application for Core Platform
+Generic Docker web application generated from the Core Platform `docker-web` software template.
 
-# Parameters
+## Tech Stack
 
-Update main parameters of templates in `Makefile`:
+- Reference container image based on `stefanprodan/podinfo`.
+- Container image built from the generated `Dockerfile`.
+- Application traffic is served on port `9898`.
 
-- `app_name` - name of the application. it defines the name of the images produced by the Makefile targets, kubernetes resources, etc.
+## Application Endpoints
 
-# Path to Production (P2P)
+- `GET /healthz` reports liveness.
+- `GET /readyz` reports readiness.
 
-The P2P uses GitHub Actions to interact with the platform.
+## Project Layout
 
-As part of the P2P, using Hierarchical Namespace Controller, child namespaces will be created:
-
-- `<tenant-name>-functional`
-- `<tenant-name>-nft`
-- `<tenant-name>-integration`
-- `<tenant-name>-extended`
-
-The application is deployed to each of this following the shape:
-
-```
-| Build Service | -> | Functional testing | -> | NF testing | -> | Integration testing | -> | Promote image to Extended tests |
-```
-
-The tests are executed as helm tests. For that to work, each test phase is packaged in a docker image and pushed to a registry.
-It's then executed after the deployment of the respective environment to ensure the service is working correctly.
-
-You can run `make p2p-help` to list the available make targets.
-
-#### Requirements
-
-The interface between the P2P and the application is `Make`.
-For everything to work for you locally you need to ensure you have the following tools installed on your machine:
-
-- Make
-- Docker
-- Kubectl
-- Helm
-
-#### Prerequisites for local run
-
-To run the P2P locally, you need to connect to a cloud development environment.
-The easiest way to [do that is using `corectl`](https://docs.coreplatform.io/platform#using-corectl).
-
-Once connected, export all env variables required to run Makefile targets, see [Executing P2P targets Locally](https://docs.coreplatform.io/p2p/reference/p2p-locally)
-for instructions.
-
-#### Image Versioning
-
-The version is automatically generated when running the pipeline in GitHub Actions, but when you build the image
-locally using `p2p-build` you may need to specify `VERSION` when running `make` command.
-
-```
-make VERSION=1.0.0 p2p-build
-```
-
-#### Building on arm64
-
-If you are on `arm64` you may find that your Docker image is not starting on the target host. This may be because of
-the incompatible target platform architecture. You may explicitly require that the image is built for `linux/amd64` platform:
-
-```
-DOCKER_DEFAULT_PLATFORM="linux/amd64" make p2p-build
-```
-
-#### Push the image
-
-There's a shared tenant registry created `europe-west2-docker.pkg.dev/<project_id>/tenant`. You'll need to set your project_id and export this string as an environment variable called `REGISTRY`, for example:
-
-```
-export REGISTRY=europe-west2-docker.pkg.dev/<project_id>/tenant
-```
-
-#### Ingress URL construction
-
-For ingress to be configured correctly,
-you'll need to set up the environment that you want to deploy to, as well as the base url to be used.
-This must match one of the `ingress_domains` configured for that environment. For example, inside CECG we have an environment called `gcp-dev` that's ingress domain is set to `gcp-dev.cecg.platform.cecg.io`.
-
-This reference app assumes `<environment>.<domain>`, check with your deployment of the Core Platform if this is the case.
-
-This will construct the base URL as `<environment>.<domain>`, for example, `gcp-dev.cecg.platform.cecg.io`.
-
-```
-export BASE_DOMAIN=gcp-dev.cecg.platform.cecg.io
-```
-
-Read [more](https://docs.coreplatform.io/application/ingress) about Ingress.
-
-#### Logs
-
-You may find the results of the test runs in Grafana. The pipeline generates a link with the specific time range.
-
-To generate a correct link to Grafana you need to make sure you have `INTERNAL_SERVICES_DOMAIN` set up.
-
-```
-export INTERNAL_SERVICES_DOMAIN=gcp-dev-internal.cecg.platform.cecg.io
-```
-
-## Functional Testing
-
-Stubbed Functional Tests using [Cucumber Godog](https://github.com/cucumber/godog)
-
-This namespace is used to test the functionality of the app. Currently, using BDD (Behaviour driven development)
-
-## Non-Functional Testing
-
-This namespace is used to test how the service behaves under load, e.g. 1k TPS, P99 latency < 2000 ms for 1 minute run.
-
-There is 1 endpoint available for testing:
-
-- `/healthz` - simply returns 200.
-
-We are using [K6](https://k6.io/) to generate constant load, collect metrics and validate them against thresholds.
-
-There is a test example: [hello.js](./resources/load-testing/hello.js)
-
-We can send the traffic to the reference app either via ingress endpoint or directly via service endpoint.
-
-There is `nft.endpoint` parameter in `values.yaml` that can be set to `ingress` or `service`.
-
-When running load tests it is important that we define CPU resource limits. This will allow us to have stable results between runs.
-
-## Integration Testing
-
-Integration Tests are using [Cucumber Godog](https://github.com/cucumber/godog)
-
-This namespace is used to test that the individual parts of the system as well as service-to-service communication
-of the app works correctly against real dependencies. Currently, using BDD (Behaviour driven development)
-
-## Extended Testing
-
-Extended Test are using [Cucumber Godog](https://github.com/cucumber/godog)
-
-This namespace is used to test that the individual parts of the system as well as service-to-service communication
-of the app works correctly against real dependencies. Currently, using BDD (Behaviour driven development)
+- `Dockerfile` defines the application image.
+- `p2p/` contains Core Platform deployment config and test containers.
+- `AGENTS.md` contains generated-repository guidance for coding agents.

--- a/go/web/skeleton/AGENTS.md
+++ b/go/web/skeleton/AGENTS.md
@@ -1,0 +1,45 @@
+# AGENTS.md - {{ name }}
+
+## Template And Tech Stack
+
+This repository was generated from the Core Platform `go-web` software template. It is a Go web service using Gin, exposes application traffic on port `8080`, exposes operational endpoints on port `8081`, and deploys with the `core-platform-assets/core-platform-app` Helm chart.
+
+## Core Platform P2P
+
+Core Platform Path to Production (P2P) is driven by GitHub Actions workflows in `.github/workflows/` and Make targets in `Makefile`. The workflows delegate to reusable workflows from `coreeng/p2p` and the Makefile downloads `p2p.mk` from the same versioned P2P contract.
+
+### Workflows
+
+- `fast-feedback.yaml` runs on pushes, pull requests, and manual dispatch. It creates a version, builds the app image, deploys the functional stage, and runs functional checks.
+- `extended-test.yaml` runs on schedule or manual dispatch. It finds the latest extended-test candidate image and runs the extended-test workflow.
+- `prod.yaml` runs on schedule or manual dispatch. It finds the latest production candidate image and deploys production.
+- `scheduled-security-scan.yaml` runs the generated repository's scheduled security scan.
+
+### Stages
+
+- Build creates and pushes the application image using the version produced by P2P.
+- Functional deploys the app to the functional namespace and runs functional tests as Helm tests.
+- Non-functional tests deploy the app to the NFT namespace and run K6 load tests as Helm tests when the NFT target is enabled.
+- Integration deploys the app to the integration namespace and runs integration tests as Helm tests.
+- Extended tests deploy the promoted image to the extended-test namespace and run longer-running validation.
+- Prod deploys the selected production candidate to the production namespace.
+
+### Configuration
+
+- `p2p/config/common.yaml` contains Helm values shared by all stages. It is rendered with environment variables before Helm receives it.
+- `p2p/config/functional.yaml` contains functional-stage overrides.
+- `p2p/config/nft.yaml` contains NFT-stage overrides.
+- `p2p/config/integration.yaml` contains integration-stage overrides.
+- `p2p/config/extended-test.yaml` contains extended-test-stage overrides.
+- `p2p/config/prod.yaml` contains production overrides.
+- Stage-specific files should only contain differences from `common.yaml`.
+
+### Tests
+
+- Unit and lint checks run before the app image is built.
+- Functional tests live in `p2p/tests/functional/` and validate externally visible app behavior.
+- Non-functional tests live in `p2p/tests/nft/` and use K6 plus Prometheus validation for load-test thresholds.
+- Integration tests live in `p2p/tests/integration/` and validate behavior against deployed dependencies.
+- Extended tests live in `p2p/tests/extended/` and are intended for longer or higher-load validation than fast feedback.
+
+Keep generated P2P contract changes aligned across `Makefile`, `.github/workflows/`, `p2p/config/`, and `p2p/tests/`.

--- a/go/web/skeleton/README.md
+++ b/go/web/skeleton/README.md
@@ -1,206 +1,23 @@
 # {{ name }}
 
-Go web application for Core Platform
+Go web application generated from the Core Platform `go-web` software template.
 
-# Parameters
+## Tech Stack
 
-Update main parameters of templates in `Makefile`:
+- Go web service using Gin.
+- Container image built from the generated `Dockerfile`.
+- Application traffic is served on port `8080`.
+- Operational endpoints are served on port `8081`.
 
-- `app_name` - name of the application. it defines the name of the images produced by the Makefile targets, kubernetes resources, etc.
+## Application Endpoints
 
-# Path to Production (P2P)
+- `GET /hello` returns a simple hello response.
+- `GET /internal/status` reports application health.
+- `GET /metrics` exposes Prometheus metrics.
 
-The P2P uses GitHub Actions to interact with the platform.
+## Project Layout
 
-As part of the P2P, using Hierarchical Namespace Controller, child namespaces will be created:
-
-- `<tenant-name>-functional`
-- `<tenant-name>-nft`
-- `<tenant-name>-integration`
-- `<tenant-name>-extended`
-
-The application is deployed to each of this following the shape:
-
-```
-| Build Service | -> | Functional testing | -> | NF testing | -> | Integration testing | -> | Promote image to Extended tests |
-```
-
-The tests are executed as helm tests. For that to work, each test phase is packaged in a docker image and pushed to a registry.
-It's then executed after the deployment of the respective environment to ensure the service is working correctly.
-
-You can run `make p2p-help` to list the available make targets.
-
-#### Requirements
-
-The interface between the P2P and the application is `Make`.
-For everything to work for you locally you need to ensure you have the following tools installed on your machine:
-
-- Make
-- Docker
-- Kubectl
-- Helm
-
-#### Prerequisites for local run
-
-To run the P2P locally, you need to connect to a cloud development environment.
-The easiest way to [do that is using `corectl`](https://docs.coreplatform.io/platform#using-corectl).
-
-Once connected, export all env variables required to run Makefile targets, see [Executing P2P targets Locally](https://docs.coreplatform.io/p2p/reference/p2p-locally)
-for instructions.
-
-#### Image Versioning
-
-The version is automatically generated when running the pipeline in GitHub Actions, but when you build the image
-locally using `p2p-build` you may need to specify `VERSION` when running `make` command.
-
-```
-make VERSION=1.0.0 p2p-build
-```
-
-#### Building on arm64
-
-If you are on `arm64` you may find that your Docker image is not starting on the target host. This may be because of
-the incompatible target platform architecture. You may explicitly require that the image is built for `linux/amd64` platform:
-
-```
-DOCKER_DEFAULT_PLATFORM="linux/amd64" make p2p-build
-```
-
-#### Push the image
-
-There's a shared tenant registry created `europe-west2-docker.pkg.dev/<project_id>/tenant`. You'll need to set your project_id and export this string as an environment variable called `REGISTRY`, for example:
-
-```
-export REGISTRY=europe-west2-docker.pkg.dev/<project_id>/tenant
-```
-
-#### Ingress URL construction
-
-For ingress to be configured correctly,
-you'll need to set up the environment that you want to deploy to, as well as the base url to be used.
-This must match one of the `ingress_domains` configured for that environment. For example, inside CECG we have an environment called `gcp-dev` that's ingress domain is set to `gcp-dev.cecg.platform.cecg.io`.
-
-This reference app assumes `<environment>.<domain>`, check with your deployment of the Core Platform if this is the case.
-
-This will construct the base URL as `<environment>.<domain>`, for example, `gcp-dev.cecg.platform.cecg.io`.
-
-```
-export BASE_DOMAIN=gcp-dev.cecg.platform.cecg.io
-```
-
-Read [more](https://docs.coreplatform.io/application/ingress) about Ingress.
-
-#### Logs
-
-You may find the results of the test runs in Grafana. The pipeline generates a link with the specific time range.
-
-To generate a correct link to Grafana you need to make sure you have `INTERNAL_SERVICES_DOMAIN` set up.
-
-```
-export INTERNAL_SERVICES_DOMAIN=gcp-dev-internal.cecg.platform.cecg.io
-```
-
-## Functional Testing
-
-Stubbed Functional Tests using [Cucumber Godog](https://github.com/cucumber/godog)
-
-This namespace is used to test the functionality of the app. Currently, using BDD (Behaviour driven development)
-
-## NFT
-
-This namespace is used to test how the service behaves under load, e.g. 1k TPS, P99 latency < 2000 ms for 1 minute run.
-
-There are 1 endpoint available for testing:
-
-- `/hello` - simply returns `Hello world`.
-
-## Integration Testing
-
-Integration Tests are using [Cucumber Godog](https://github.com/cucumber/godog)
-
-This namespace is used to test that the individual parts of the system as well as service-to-service communication
-of the app works correctly against real dependencies. Currently, using BDD (Behaviour driven development)
-
-#### Load Generation
-
-We are using [K6](https://k6.io/) to generate constant load, collect metrics and validate them against thresholds.
-
-There is a test examples: [hello.js](./resources/load-testing/hello.js)
-
-`helm test` runs K6 scenario in a single Pod.
-
-#### Platform Ingress
-
-We can send the traffic to the reference app either via ingress endpoint or directly via service endpoint.
-
-There is `nft.endpoint` parameter in `values.yaml` that can be set to `ingress` or `service`.
-
-## Extended test
-
-This is similar to NFT, but generates much higher load and runs longer, e.g. 10k TPS, P99 latency < 2000 ms for 10 minutes run.
-
-#### Load Generation
-
-We are using [K6](https://k6.io/) to generate the load.
-We are using [K6 Operator](https://github.com/grafana/k6-operator) to run multiple jobs in parallel, so that we can reach high
-TPS requirements.
-
-When running parallel jobs with K6 Operator we are not getting back the aggregated metrics at the end of the test.
-We are collecting the metrics with Prometheus and validating the results with `promtool`.
-
-#### Platform Ingress
-
-We can send the traffic to the reference app either via ingress endpoint or directly via service endpoint.
-See NFT section for more details.
-
-## Platform Features
-
-> Due to the restrictions applied to your platform you may not be able to enable some of the features
-
-### Monitoring
-
-This feature is needed to allow metrics collection by Prometheus. It needs the metric store (prometheus) to be installed on the parent namespace e.g. `TENANT_NAME`.
-
-By default, Monitoring is disabled. In order to enable it, you need to explicitly override the variable
-
-```
-make MONITORING=true p2p-nft
-```
-
-or change `MONITORING` to `true` in `Makefile`.
-
-### Dashboarding
-
-This feature allows you to automatically import dashboard definitions to Grafana.
-
-> You may import the dashboard manually by uploading the json definition via browser
-
-By default, `DASHBOARDING` is disabled. In order to enable it, you need to explicitly override the variable
-
-```
-make DASHBOARDING=true p2p-nft
-```
-
-or change `DASHBOARDING` to `true` in `Makefile`.
-
-The reference app comes with `10k TPS Reference App` dashboard that shows the TPS and latency
-for the load generator, ingress, API server and its downstream dependency.
-
-This feature depends on metrics collected by `Service Monitor`.
-
-### K6 Operator
-
-> K6 Operator must be enabled for the tenant to run the extended test
-
-You can enable it by enabling the beta feature in the tenant.yaml file:
-
-```yaml
-betaFeatures:
-  - k6-operator
-```
-
-## Limiting the CPU usage
-
-When running load tests it is important that we define CPU resource limits. This will allow us to have stable results between runs.
-
-If we don't apply the limits then the performance of the Pods will depend on the CPU utilization of the node that is running the container.
+- `cmd/service/` contains the service entry point.
+- `cmd/handler/` contains HTTP handlers.
+- `p2p/` contains Core Platform deployment config and test containers.
+- `AGENTS.md` contains generated-repository guidance for coding agents.

--- a/java/web/skeleton/AGENTS.md
+++ b/java/web/skeleton/AGENTS.md
@@ -1,0 +1,45 @@
+# AGENTS.md - {{ name }}
+
+## Template And Tech Stack
+
+This repository was generated from the Core Platform `java-web` software template. It is a Java Spring Boot web service built with Gradle, exposes application traffic on port `8080`, exposes operational endpoints on port `8081`, and deploys with the `core-platform-assets/core-platform-app` Helm chart.
+
+## Core Platform P2P
+
+Core Platform Path to Production (P2P) is driven by GitHub Actions workflows in `.github/workflows/` and Make targets in `Makefile`. The workflows delegate to reusable workflows from `coreeng/p2p` and the Makefile downloads `p2p.mk` from the same versioned P2P contract.
+
+### Workflows
+
+- `fast-feedback.yaml` runs on pushes, pull requests, and manual dispatch. It creates a version, builds the app image, deploys the functional stage, and runs functional checks.
+- `extended-test.yaml` runs on schedule or manual dispatch. It finds the latest extended-test candidate image and runs the extended-test workflow.
+- `prod.yaml` runs on schedule or manual dispatch. It finds the latest production candidate image and deploys production.
+- `scheduled-security-scan.yaml` runs the generated repository's scheduled security scan.
+
+### Stages
+
+- Build creates and pushes the application image using the version produced by P2P.
+- Functional deploys the app to the functional namespace and runs functional tests as Helm tests.
+- Non-functional tests deploy the app to the NFT namespace and run K6 load tests as Helm tests when the NFT target is enabled.
+- Integration deploys the app to the integration namespace and runs integration tests as Helm tests.
+- Extended tests deploy the promoted image to the extended-test namespace and run longer-running validation.
+- Prod deploys the selected production candidate to the production namespace.
+
+### Configuration
+
+- `p2p/config/common.yaml` contains Helm values shared by all stages. It is rendered with environment variables before Helm receives it.
+- `p2p/config/functional.yaml` contains functional-stage overrides.
+- `p2p/config/nft.yaml` contains NFT-stage overrides.
+- `p2p/config/integration.yaml` contains integration-stage overrides.
+- `p2p/config/extended-test.yaml` contains extended-test-stage overrides.
+- `p2p/config/prod.yaml` contains production overrides.
+- Stage-specific files should only contain differences from `common.yaml`.
+
+### Tests
+
+- Unit and lint checks run before the app image is built.
+- Functional tests live in `p2p/tests/functional/` and validate externally visible app behavior.
+- Non-functional tests live in `p2p/tests/nft/` and use K6 plus Prometheus validation for load-test thresholds.
+- Integration tests live in `p2p/tests/integration/` and validate behavior against deployed dependencies.
+- Extended tests live in `p2p/tests/extended/` and are intended for longer or higher-load validation than fast feedback.
+
+Keep generated P2P contract changes aligned across `Makefile`, `.github/workflows/`, `p2p/config/`, and `p2p/tests/`.

--- a/java/web/skeleton/README.md
+++ b/java/web/skeleton/README.md
@@ -1,206 +1,23 @@
 # {{ name }}
 
-Java web application for Core Platform
+Java web application generated from the Core Platform `java-web` software template.
 
-# Parameters
+## Tech Stack
 
-Update main parameters of templates in `Makefile`:
+- Java Spring Boot web service.
+- Gradle build with the generated Gradle wrapper.
+- Container image built from the generated `Dockerfile`.
+- Application traffic is served on port `8080`.
+- Operational endpoints are served on port `8081`.
 
-- `app_name` - name of the application. it defines the name of the images produced by the Makefile targets, kubernetes resources, etc.
+## Application Endpoints
 
-# Path to Production (P2P)
+- `GET /hello` returns a simple hello response.
+- `GET /health` reports application health.
+- `GET /prometheus` exposes Prometheus metrics.
 
-The P2P uses GitHub Actions to interact with the platform.
+## Project Layout
 
-As part of the P2P, using Hierarchical Namespace Controller, child namespaces will be created:
-
-- `<tenant-name>-functional`
-- `<tenant-name>-nft`
-- `<tenant-name>-integration`
-- `<tenant-name>-extended`
-
-The application is deployed to each of this following the shape:
-
-```
-| Build Service | -> | Functional testing | -> | NF testing | -> | Integration testing | -> | Promote image to Extended tests |
-```
-
-The tests are executed as helm tests. For that to work, each test phase is packaged in a docker image and pushed to a registry.
-It's then executed after the deployment of the respective environment to ensure the service is working correctly.
-
-You can run `make p2p-help` to list the available make targets.
-
-#### Requirements
-
-The interface between the P2P and the application is `Make`.
-For everything to work for you locally you need to ensure you have the following tools installed on your machine:
-
-- Make
-- Docker
-- Kubectl
-- Helm
-
-#### Prerequisites for local run
-
-To run the P2P locally, you need to connect to a cloud development environment.
-The easiest way to [do that is using `corectl`](https://docs.coreplatform.io/platform#using-corectl).
-
-Once connected, export all env variables required to run Makefile targets, see [Executing P2P targets Locally](https://docs.coreplatform.io/p2p/reference/p2p-locally)
-for instructions.
-
-#### Image Versioning
-
-The version is automatically generated when running the pipeline in GitHub Actions, but when you build the image
-locally using `p2p-build` you may need to specify `VERSION` when running `make` command.
-
-```
-make VERSION=1.0.0 p2p-build
-```
-
-#### Building on arm64
-
-If you are on `arm64` you may find that your Docker image is not starting on the target host. This may be because of
-the incompatible target platform architecture. You may explicitly require that the image is built for `linux/amd64` platform:
-
-```
-DOCKER_DEFAULT_PLATFORM="linux/amd64" make p2p-build
-```
-
-#### Push the image
-
-There's a shared tenant registry created `europe-west2-docker.pkg.dev/<project_id>/tenant`. You'll need to set your project_id and export this string as an environment variable called `REGISTRY`, for example:
-
-```
-export REGISTRY=europe-west2-docker.pkg.dev/<project_id>/tenant
-```
-
-#### Ingress URL construction
-
-For ingress to be configured correctly,
-you'll need to set up the environment that you want to deploy to, as well as the base url to be used.
-This must match one of the `ingress_domains` configured for that environment. For example, inside CECG we have an environment called `gcp-dev` that's ingress domain is set to `gcp-dev.cecg.platform.cecg.io`.
-
-This reference app assumes `<environment>.<domain>`, check with your deployment of the Core Platform if this is the case.
-
-This will construct the base URL as `<environment>.<domain>`, for example, `gcp-dev.cecg.platform.cecg.io`.
-
-```
-export BASE_DOMAIN=gcp-dev.cecg.platform.cecg.io
-```
-
-Read [more](https://docs.coreplatform.io/application/ingress) about Ingress.
-
-#### Logs
-
-You may find the results of the test runs in Grafana. The pipeline generates a link with the specific time range.
-
-To generate a correct link to Grafana you need to make sure you have `INTERNAL_SERVICES_DOMAIN` set up.
-
-```
-export INTERNAL_SERVICES_DOMAIN=gcp-dev-internal.cecg.platform.cecg.io
-```
-
-## Functional Testing
-
-Stubbed Functional Tests using [Cucumber Java](https://cucumber.io/docs/installation/java)
-
-This namespace is used to test the functionality of the app. Currently, using BDD (Behaviour driven development)
-
-## NFT
-
-This namespace is used to test how the service behaves under load, e.g. 1k TPS, P99 latency < 2000 ms for 1 minute run.
-
-There are 1 endpoint available for testing:
-
-- `/hello` - simply returns `Hello world`.
-
-## Integration Testing
-
-Integration Tests are using [Cucumber Java](https://cucumber.io/docs/installation/java)
-
-This namespace is used to test that the individual parts of the system as well as service-to-service communication
-of the app works correctly against real dependencies. Currently, using BDD (Behaviour driven development)
-
-#### Load Generation
-
-We are using [K6](https://k6.io/) to generate constant load, collect metrics and validate them against thresholds.
-
-There is a test examples: [hello.js](./resources/load-testing/hello.js)
-
-`helm test` runs K6 scenario in a single Pod.
-
-#### Platform Ingress
-
-We can send the traffic to the reference app either via ingress endpoint or directly via service endpoint.
-
-There is `nft.endpoint` parameter in `values.yaml` that can be set to `ingress` or `service`.
-
-## Extended test
-
-This is similar to NFT, but generates much higher load and runs longer, e.g. 10k TPS, P99 latency < 2000 ms for 10 minutes run.
-
-#### Load Generation
-
-We are using [K6](https://k6.io/) to generate the load.
-We are using [K6 Operator](https://github.com/grafana/k6-operator) to run multiple jobs in parallel, so that we can reach high
-TPS requirements.
-
-When running parallel jobs with K6 Operator we are not getting back the aggregated metrics at the end of the test.
-We are collecting the metrics with Prometheus and validating the results with `promtool`.
-
-#### Platform Ingress
-
-We can send the traffic to the reference app either via ingress endpoint or directly via service endpoint.
-See NFT section for more details.
-
-## Platform Features
-
-> Due to the restrictions applied to your platform you may not be able to enable some of the features
-
-### Monitoring
-
-This feature is needed to allow metrics collection by Prometheus. It needs the metric store (prometheus) to be installed on the parent namespace e.g. `TENANT_NAME`.
-
-By default, Monitoring is disabled. In order to enable it, you need to explicitly override the variable
-
-```
-make MONITORING=true p2p-nft
-```
-
-or change `MONITORING` to `true` in `Makefile`.
-
-### Dashboarding
-
-This feature allows you to automatically import dashboard definitions to Grafana.
-
-> You may import the dashboard manually by uploading the json definition via browser
-
-By default, `DASHBOARDING` is disabled. In order to enable it, you need to explicitly override the variable
-
-```
-make DASHBOARDING=true p2p-nft
-```
-
-or change `DASHBOARDING` to `true` in `Makefile`.
-
-The reference app comes with `10k TPS Reference App` dashboard that shows the TPS and latency
-for the load generator, ingress, API server and its downstream dependency.
-
-This feature depends on metrics collected by `Service Monitor`.
-
-### K6 Operator
-
-> K6 Operator must be enabled for the tenant to run the extended test
-
-You can enable it by enabling the beta feature in the tenant.yaml file:
-
-```yaml
-betaFeatures:
-  - k6-operator
-```
-
-## Limiting the CPU usage
-
-When running load tests it is important that we define CPU resource limits. This will allow us to have stable results between runs.
-
-If we don't apply the limits then the performance of the Pods will depend on the CPU utilization of the node that is running the container.
+- `service/` contains the Spring Boot application.
+- `p2p/` contains Core Platform deployment config and test containers.
+- `AGENTS.md` contains generated-repository guidance for coding agents.

--- a/monitoring-stack/skeleton/AGENTS.md
+++ b/monitoring-stack/skeleton/AGENTS.md
@@ -1,0 +1,31 @@
+# AGENTS.md - {{ name }}
+
+## Template And Tech Stack
+
+This repository was generated from the Core Platform `monitoring-stack` software template. It deploys the `core-platform-assets/core-platform-monitoring` Helm chart, which provides Prometheus, Grafana, and Alertmanager for a delivery unit.
+
+## Core Platform P2P
+
+Core Platform Path to Production (P2P) is driven by GitHub Actions workflows in `.github/workflows/` and Make targets in `Makefile`. This template is deploy-oriented: it builds a lightweight runner image, deploys the monitoring chart, and validates the integration deployment.
+
+### Workflows
+
+- `fast-feedback.yaml` creates a version and builds the generated image.
+- `extended-test.yaml` exists for the standard repository workflow set, but this template's active validation is integration-focused.
+- `prod.yaml` finds the selected production candidate and deploys production.
+- `scheduled-security-scan.yaml` runs the generated repository's scheduled security scan.
+
+### Stages
+
+- Build creates and pushes the generated image using the version produced by P2P.
+- Integration deploys the monitoring chart to the integration namespace and runs the integration validation container.
+- Prod deploys the selected production candidate to the production namespace.
+
+### Configuration
+
+- `p2p/config/common.yaml` contains Helm values shared by monitoring deployments.
+- `p2p/config/integration.yaml` lists integration namespaces and target instances to monitor.
+- `p2p/config/prod.yaml` lists production namespaces and target instances to monitor.
+- Add monitored delivery units by updating `prometheus.targetNamespaces` and `prometheus.targetInstances` in the stage-specific config file.
+
+Keep generated P2P contract changes aligned across `Makefile`, `.github/workflows/`, `p2p/config/`, and `p2p/tests/`.

--- a/monitoring-stack/skeleton/README.md
+++ b/monitoring-stack/skeleton/README.md
@@ -1,32 +1,27 @@
 # {{ name }}
 
-Shared Core Platform monitoring stack.
+Shared monitoring stack generated from the Core Platform `monitoring-stack` software template.
 
-This repository is generated from the `monitoring-stack` software template. It deploys the
-`core-platform-assets/core-platform-monitoring` Helm chart through the integration and prod P2P stages.
+This repository deploys the `core-platform-assets/core-platform-monitoring` Helm chart for a delivery unit.
 
-## Deployment
+## Tech Stack
 
-Use the generated P2P targets:
+- Prometheus for metrics collection.
+- Grafana for dashboards.
+- Alertmanager for alert routing.
+- Helm values in `p2p/config/` for environment-specific configuration.
 
-```bash
-make p2p-integration
-make p2p-prod
-```
+## Monitored Delivery Units
 
-## Monitoring Targets
-
-The generated Helm values monitor this delivery unit by default:
+The generated values monitor this delivery unit by default:
 
 - non-production stages: `{{ name }}-integration`
 - production: `{{ name }}-prod`
 - target instance: `{{ name }}`
 
-To monitor additional delivery units, edit the environment values files and add each delivery unit's
-namespace under `prometheus.targetNamespaces` and instance name under `prometheus.targetInstances`.
+To monitor additional delivery units, edit the environment values files and add each delivery unit namespace under `prometheus.targetNamespaces` and instance name under `prometheus.targetInstances`.
 
-For example, to monitor `payments-api` and `orders-api` in integration, update
-`p2p/config/integration.yaml`:
+For integration, update `p2p/config/integration.yaml`:
 
 ```yaml
 prometheus:
@@ -40,7 +35,7 @@ prometheus:
     - orders-api
 ```
 
-For production, update `p2p/config/prod.yaml` with production namespaces:
+For production, update `p2p/config/prod.yaml`:
 
 ```yaml
 prometheus:
@@ -54,20 +49,9 @@ prometheus:
     - orders-api
 ```
 
-## Description
-
-The generated `app.yaml` contains the repository description:
-
-```yaml
-description: Shared Core Platform monitoring stack
-```
-
-Change that value in the generated repository if a team-specific description is needed.
-
 ## Slack Alerting
 
-Slack settings are regular Helm values in the generated repository. To set the Slack channel, add
-`alertmanager.slack.channel` to the relevant environment values file. For example:
+Slack settings are regular Helm values in the generated repository. To set the Slack channel, add `alertmanager.slack.channel` to the relevant environment values file:
 
 ```yaml
 alertmanager:
@@ -77,11 +61,6 @@ alertmanager:
     webhookSecretKey: url
 ```
 
-The secret named by `webhookSecretName` must exist in the monitoring namespace and contain the key
-named by `webhookSecretKey`. The template does not create Slack webhook secrets.
+The secret named by `webhookSecretName` must exist in the monitoring namespace and contain the key named by `webhookSecretKey`. The template does not create Slack webhook secrets.
 
-## P2P Validation
-
-The P2P integration stage deploys this monitoring chart and then runs `helm test` if the chart defines
-Helm test hooks. If the chart has no test hooks, the stage treats successful deployment as deploy-only
-validation.
+`AGENTS.md` contains generated-repository guidance for coding agents.

--- a/nextjs/web/skeleton/AGENTS.md
+++ b/nextjs/web/skeleton/AGENTS.md
@@ -1,0 +1,45 @@
+# AGENTS.md - {{ name }}
+
+## Template And Tech Stack
+
+This repository was generated from the Core Platform `nextjs-web` software template. It is a Next.js application using React and TypeScript, serves application traffic on port `3000`, exposes metrics on port `8081`, and deploys with the `core-platform-assets/core-platform-app` Helm chart.
+
+## Core Platform P2P
+
+Core Platform Path to Production (P2P) is driven by GitHub Actions workflows in `.github/workflows/` and Make targets in `Makefile`. The workflows delegate to reusable workflows from `coreeng/p2p` and the Makefile downloads `p2p.mk` from the same versioned P2P contract.
+
+### Workflows
+
+- `fast-feedback.yaml` runs on pushes, pull requests, and manual dispatch. It creates a version, builds the app image, deploys the functional stage, and runs functional checks.
+- `extended-test.yaml` runs on schedule or manual dispatch. It finds the latest extended-test candidate image and runs the extended-test workflow.
+- `prod.yaml` runs on schedule or manual dispatch. It finds the latest production candidate image and deploys production.
+- `scheduled-security-scan.yaml` runs the generated repository's scheduled security scan.
+
+### Stages
+
+- Build creates and pushes the application image using the version produced by P2P.
+- Functional deploys the app to the functional namespace and runs functional tests as Helm tests.
+- Non-functional tests deploy the app to the NFT namespace and run K6 load tests as Helm tests when the NFT target is enabled.
+- Integration deploys the app to the integration namespace and runs integration tests as Helm tests.
+- Extended tests deploy the promoted image to the extended-test namespace and run longer-running validation.
+- Prod deploys the selected production candidate to the production namespace.
+
+### Configuration
+
+- `p2p/config/common.yaml` contains Helm values shared by all stages. It is rendered with environment variables before Helm receives it.
+- `p2p/config/functional.yaml` contains functional-stage overrides.
+- `p2p/config/nft.yaml` contains NFT-stage overrides.
+- `p2p/config/integration.yaml` contains integration-stage overrides.
+- `p2p/config/extended-test.yaml` contains extended-test-stage overrides.
+- `p2p/config/prod.yaml` contains production overrides.
+- Stage-specific files should only contain differences from `common.yaml`.
+
+### Tests
+
+- Unit and lint checks run before the app image is built.
+- Functional tests live in `p2p/tests/functional/` and validate externally visible app behavior with Cucumber and Playwright.
+- Non-functional tests live in `p2p/tests/nft/` and use K6 plus Prometheus validation for load-test thresholds.
+- Integration tests live in `p2p/tests/integration/` and validate behavior against deployed dependencies.
+- Extended tests live in `p2p/tests/extended/` and are intended for longer or higher-load validation than fast feedback.
+
+Keep generated P2P contract changes aligned across `Makefile`, `.github/workflows/`, `p2p/config/`, and `p2p/tests/`.

--- a/nextjs/web/skeleton/README.md
+++ b/nextjs/web/skeleton/README.md
@@ -1,206 +1,25 @@
 # {{ name }}
 
-Next.js web application for Core Platform
+Next.js web application generated from the Core Platform `nextjs-web` software template.
 
-# Parameters
+## Tech Stack
 
-Update main parameters of templates in `Makefile`:
+- Next.js application using React and TypeScript.
+- Yarn-managed JavaScript dependencies.
+- Container image built from the generated `Dockerfile`.
+- Application traffic is served on port `3000`.
+- Metrics are served on port `8081`.
 
-- `app_name` - name of the application. it defines the name of the images produced by the Makefile targets, kubernetes resources, etc.
+## Application Endpoints
 
-# Path to Production (P2P)
+- `GET /` serves the application home page.
+- `GET /readyz` reports readiness.
+- `GET /livez` reports liveness.
+- `GET /metrics` exposes Prometheus metrics.
 
-The P2P uses GitHub Actions to interact with the platform.
+## Project Layout
 
-As part of the P2P, using Hierarchical Namespace Controller, child namespaces will be created:
-
-- `<tenant-name>-functional`
-- `<tenant-name>-nft`
-- `<tenant-name>-integration`
-- `<tenant-name>-extended`
-
-The application is deployed to each of this following the shape:
-
-```
-| Build Service | -> | Functional testing | -> | NF testing | -> | Integration testing | -> | Promote image to Extended tests |
-```
-
-The tests are executed as helm tests. For that to work, each test phase is packaged in a docker image and pushed to a registry.
-It's then executed after the deployment of the respective environment to ensure the service is working correctly.
-
-You can run `make p2p-help` to list the available make targets.
-
-#### Requirements
-
-The interface between the P2P and the application is `Make`.
-For everything to work for you locally you need to ensure you have the following tools installed on your machine:
-
-- Make
-- Docker
-- Kubectl
-- Helm
-
-#### Prerequisites for local run
-
-To run the P2P locally, you need to connect to a cloud development environment.
-The easiest way to [do that is using `corectl`](https://docs.coreplatform.io/platform#using-corectl).
-
-Once connected, export all env variables required to run Makefile targets, see [Executing P2P targets Locally](https://docs.coreplatform.io/p2p/reference/p2p-locally)
-for instructions.
-
-#### Image Versioning
-
-The version is automatically generated when running the pipeline in GitHub Actions, but when you build the image
-locally using `p2p-build` you may need to specify `VERSION` when running `make` command.
-
-```
-make VERSION=1.0.0 p2p-build
-```
-
-#### Building on arm64
-
-If you are on `arm64` you may find that your Docker image is not starting on the target host. This may be because of
-the incompatible target platform architecture. You may explicitly require that the image is built for `linux/amd64` platform:
-
-```
-DOCKER_DEFAULT_PLATFORM="linux/amd64" make p2p-build
-```
-
-#### Push the image
-
-There's a shared tenant registry created `europe-west2-docker.pkg.dev/<project_id>/tenant`. You'll need to set your project_id and export this string as an environment variable called `REGISTRY`, for example:
-
-```
-export REGISTRY=europe-west2-docker.pkg.dev/<project_id>/tenant
-```
-
-#### Ingress URL construction
-
-For ingress to be configured correctly,
-you'll need to set up the environment that you want to deploy to, as well as the base url to be used.
-This must match one of the `ingress_domains` configured for that environment. For example, inside CECG we have an environment called `gcp-dev` that's ingress domain is set to `gcp-dev.cecg.platform.cecg.io`.
-
-This reference app assumes `<environment>.<domain>`, check with your deployment of the Core Platform if this is the case.
-
-This will construct the base URL as `<environment>.<domain>`, for example, `gcp-dev.cecg.platform.cecg.io`.
-
-```
-export BASE_DOMAIN=gcp-dev.cecg.platform.cecg.io
-```
-
-Read [more](https://docs.coreplatform.io/application/ingress) about Ingress.
-
-#### Logs
-
-You may find the results of the test runs in Grafana. The pipeline generates a link with the specific time range.
-
-To generate a correct link to Grafana you need to make sure you have `INTERNAL_SERVICES_DOMAIN` set up.
-
-```
-export INTERNAL_SERVICES_DOMAIN=gcp-dev-internal.cecg.platform.cecg.io
-```
-
-## Functional Testing
-
-Stubbed Functional Tests using [Cucumber JS](https://cucumber.io/docs/installation/javascript)
-
-This namespace is used to test the functionality of the app. Currently, using BDD (Behaviour driven development)
-
-## NFT
-
-This namespace is used to test how the service behaves under load, e.g. 1k TPS, P99 latency < 2000 ms for 1 minute run.
-
-There are 1 endpoint available for testing:
-
-- `/hello` - simply returns `Hello world`.
-
-## Integration Testing
-
-Integration Tests are using [Cucumber JS](https://cucumber.io/docs/installation/javascript)
-
-This namespace is used to test that the individual parts of the system as well as service-to-service communication
-of the app works correctly against real dependencies. Currently, using BDD (Behaviour driven development)
-
-#### Load Generation
-
-We are using [K6](https://k6.io/) to generate constant load, collect metrics and validate them against thresholds.
-
-There is a test examples: [hello.js](./resources/load-testing/hello.js)
-
-`helm test` runs K6 scenario in a single Pod.
-
-#### Platform Ingress
-
-We can send the traffic to the reference app either via ingress endpoint or directly via service endpoint.
-
-There is `nft.endpoint` parameter in `values.yaml` that can be set to `ingress` or `service`.
-
-## Extended test
-
-This is similar to NFT, but generates much higher load and runs longer, e.g. 10k TPS, P99 latency < 2000 ms for 10 minutes run.
-
-#### Load Generation
-
-We are using [K6](https://k6.io/) to generate the load.
-We are using [K6 Operator](https://github.com/grafana/k6-operator) to run multiple jobs in parallel, so that we can reach high
-TPS requirements.
-
-When running parallel jobs with K6 Operator we are not getting back the aggregated metrics at the end of the test.
-We are collecting the metrics with Prometheus and validating the results with `promtool`.
-
-#### Platform Ingress
-
-We can send the traffic to the reference app either via ingress endpoint or directly via service endpoint.
-See NFT section for more details.
-
-## Platform Features
-
-> Due to the restrictions applied to your platform you may not be able to enable some of the features
-
-### Monitoring
-
-This feature is needed to allow metrics collection by Prometheus. It needs the metric store (prometheus) to be installed on the parent namespace e.g. `TENANT_NAME`.
-
-By default, Monitoring is disabled. In order to enable it, you need to explicitly override the variable
-
-```
-make MONITORING=true p2p-nft
-```
-
-or change `MONITORING` to `true` in `Makefile`.
-
-### Dashboarding
-
-This feature allows you to automatically import dashboard definitions to Grafana.
-
-> You may import the dashboard manually by uploading the json definition via browser
-
-By default, `DASHBOARDING` is disabled. In order to enable it, you need to explicitly override the variable
-
-```
-make DASHBOARDING=true p2p-nft
-```
-
-or change `DASHBOARDING` to `true` in `Makefile`.
-
-The reference app comes with `10k TPS Reference App` dashboard that shows the TPS and latency
-for the load generator, ingress, API server and its downstream dependency.
-
-This feature depends on metrics collected by `Service Monitor`.
-
-### K6 Operator
-
-> K6 Operator must be enabled for the tenant to run the extended test
-
-You can enable it by enabling the beta feature in the tenant.yaml file:
-
-```yaml
-betaFeatures:
-  - k6-operator
-```
-
-## Limiting the CPU usage
-
-When running load tests it is important that we define CPU resource limits. This will allow us to have stable results between runs.
-
-If we don't apply the limits then the performance of the Pods will depend on the CPU utilization of the node that is running the container.
+- `src/app/` contains the Next.js app router pages and route handlers.
+- `src/lib/` contains shared runtime support.
+- `p2p/` contains Core Platform deployment config and test containers.
+- `AGENTS.md` contains generated-repository guidance for coding agents.

--- a/python/web/skeleton/AGENTS.md
+++ b/python/web/skeleton/AGENTS.md
@@ -1,0 +1,45 @@
+# AGENTS.md - {{ name }}
+
+## Template And Tech Stack
+
+This repository was generated from the Core Platform `python-web` software template. It is a Python FastAPI web service managed with `uv`, exposes application traffic on port `8080`, exposes operational endpoints on port `8081`, and deploys with the `core-platform-assets/core-platform-app` Helm chart.
+
+## Core Platform P2P
+
+Core Platform Path to Production (P2P) is driven by GitHub Actions workflows in `.github/workflows/` and Make targets in `Makefile`. The workflows delegate to reusable workflows from `coreeng/p2p` and the Makefile downloads `p2p.mk` from the same versioned P2P contract.
+
+### Workflows
+
+- `fast-feedback.yaml` runs on pushes, pull requests, and manual dispatch. It creates a version, builds the app image, deploys the functional stage, and runs functional checks.
+- `extended-test.yaml` runs on schedule or manual dispatch. It finds the latest extended-test candidate image and runs the extended-test workflow.
+- `prod.yaml` runs on schedule or manual dispatch. It finds the latest production candidate image and deploys production.
+- `scheduled-security-scan.yaml` runs the generated repository's scheduled security scan.
+
+### Stages
+
+- Build creates and pushes the application image using the version produced by P2P.
+- Functional deploys the app to the functional namespace and runs functional tests as Helm tests.
+- Non-functional tests deploy the app to the NFT namespace and run K6 load tests as Helm tests when the NFT target is enabled.
+- Integration deploys the app to the integration namespace and runs integration tests as Helm tests.
+- Extended tests deploy the promoted image to the extended-test namespace and run longer-running validation.
+- Prod deploys the selected production candidate to the production namespace.
+
+### Configuration
+
+- `p2p/config/common.yaml` contains Helm values shared by all stages. It is rendered with environment variables before Helm receives it.
+- `p2p/config/functional.yaml` contains functional-stage overrides.
+- `p2p/config/nft.yaml` contains NFT-stage overrides.
+- `p2p/config/integration.yaml` contains integration-stage overrides.
+- `p2p/config/extended-test.yaml` contains extended-test-stage overrides.
+- `p2p/config/prod.yaml` contains production overrides.
+- Stage-specific files should only contain differences from `common.yaml`.
+
+### Tests
+
+- Unit and lint checks run before the app image is built.
+- Functional tests live in `p2p/tests/functional/` and validate externally visible app behavior with Behave.
+- Non-functional tests live in `p2p/tests/nft/` and use K6 plus Prometheus validation for load-test thresholds.
+- Integration tests live in `p2p/tests/integration/` and validate behavior against deployed dependencies.
+- Extended tests live in `p2p/tests/extended/` and are intended for longer or higher-load validation than fast feedback.
+
+Keep generated P2P contract changes aligned across `Makefile`, `.github/workflows/`, `p2p/config/`, and `p2p/tests/`.

--- a/python/web/skeleton/README.md
+++ b/python/web/skeleton/README.md
@@ -1,122 +1,43 @@
 # {{ name }}
 
-Python web application for Core Platform
+Python web application generated from the Core Platform `python-web` software template.
 
-## Overview
+## Tech Stack
 
-The service exposes two ports:
+- Python FastAPI web service.
+- `uv` for dependency management and local commands.
+- Container image built from the generated `Dockerfile`.
+- Application traffic is served on port `8080`.
+- Operational endpoints are served on port `8081`.
 
-| Port | Purpose |
-|------|---------|
-| 8080 | Application traffic (`GET /hello`) |
-| 8081 | Internal/ops traffic (`GET /metrics`, `GET /internal/status`) |
+## Application Endpoints
 
-## P2P Overview
-
-The Path to Production (P2P) pipeline progresses through these namespaces:
-
-| Stage | Namespace | Triggered by |
-|-------|-----------|-------------|
-| Fast Feedback | `{{ tenant }}-functional` | Push / PR to `main` |
-| NFT | `{{ tenant }}-nft` | Fast Feedback |
-| Integration | `{{ tenant }}-integration` | Fast Feedback |
-| Extended Test | `{{ tenant }}-extended-test` | Daily schedule (22:00 UTC) |
-| Prod | `{{ tenant }}-prod` | Weekday schedule (05:30 UTC) |
+- `GET /hello` returns a simple hello response.
+- `GET /internal/status` reports application health.
+- `GET /metrics` exposes Prometheus metrics.
 
 ## Local Development
 
-### Prerequisites
-
-- [uv](https://docs.astral.sh/uv/) — Python package manager
-- Python 3.13+
-- Docker (for building and running containers)
-
-### Setup
-
 ```bash
 uv sync
-```
-
-### Run locally
-
-```bash
 uv run python -m app.main
 ```
 
-The service will be available at:
-- `http://localhost:8080/hello`
-- `http://localhost:8081/internal/status`
-- `http://localhost:8081/metrics`
-
-### Run unit tests
+Run unit tests with:
 
 ```bash
 uv run pytest
 ```
 
-### Lint
+Run lint checks with:
 
 ```bash
 uv run ruff check src/ tests/
 ```
 
-## Image Versioning
+## Project Layout
 
-Images are versioned automatically by the P2P pipeline using the commit SHA. To build and run locally:
-
-```bash
-export VERSION=local
-export REGISTRY=localhost
-make build-app
-make run-app
-```
-
-> **ARM64 note:** On Apple Silicon, set `DOCKER_DEFAULT_PLATFORM=linux/amd64` to build images compatible with the cluster.
-
-## Testing
-
-### Functional Tests
-
-BDD tests using [Behave](https://behave.readthedocs.io/) (Python Cucumber). They run against the deployed service in the `functional` namespace.
-
-```bash
-make p2p-functional
-```
-
-Feature files are in `p2p/tests/functional/features/`.
-
-### NFT (Non-Functional Tests)
-
-Load tests using [K6](https://k6.io/). Default target: 1,000 req/s for 1 minute with P99 < 2000ms.
-
-```bash
-make p2p-nft
-```
-
-Scripts are in `p2p/tests/nft/resources/load-testing/`.
-
-### Integration Tests
-
-BDD tests that run against real downstream dependencies in the `integration` namespace.
-
-```bash
-make p2p-integration
-```
-
-### Extended Tests
-
-Higher-load / longer-running tests scheduled nightly. Placeholder — implement as needed.
-
-## Platform Features
-
-### Monitoring
-
-Prometheus metrics are exposed on port 8081 at `/metrics`. The Helm chart configures scraping automatically when `metrics.enabled: true`.
-
-### Dashboarding
-
-A Grafana dashboard is available via the internal services domain once the app is deployed. Log links are printed at the end of each test run.
-
-### K6 Operator
-
-The NFT and Extended test stages use the K6 Operator on the cluster. The custom K6 build includes the [xk6-prometheus](https://github.com/coreeng/xk6-prometheus) extension so metrics are exported to Prometheus during load tests.
+- `src/app/` contains the FastAPI application.
+- `tests/` contains unit tests.
+- `p2p/` contains Core Platform deployment config and test containers.
+- `AGENTS.md` contains generated-repository guidance for coding agents.

--- a/static/nextra/skeleton/AGENTS.md
+++ b/static/nextra/skeleton/AGENTS.md
@@ -1,0 +1,45 @@
+# AGENTS.md - {{ name }}
+
+## Template And Tech Stack
+
+This repository was generated from the Core Platform `static-nextra` software template. It is a Nextra documentation site built on Next.js and React, serves application traffic on port `3000`, exposes metrics on port `8081`, and deploys with the `core-platform-assets/core-platform-app` Helm chart.
+
+## Core Platform P2P
+
+Core Platform Path to Production (P2P) is driven by GitHub Actions workflows in `.github/workflows/` and Make targets in `Makefile`. The workflows delegate to reusable workflows from `coreeng/p2p` and the Makefile downloads `p2p.mk` from the same versioned P2P contract.
+
+### Workflows
+
+- `fast-feedback.yaml` runs on pushes, pull requests, and manual dispatch. It creates a version, builds the app image, deploys the functional stage, and runs functional checks.
+- `extended-test.yaml` runs on schedule or manual dispatch. It finds the latest extended-test candidate image and runs the extended-test workflow.
+- `prod.yaml` runs on schedule or manual dispatch. It finds the latest production candidate image and deploys production.
+- `scheduled-security-scan.yaml` runs the generated repository's scheduled security scan.
+
+### Stages
+
+- Build creates and pushes the application image using the version produced by P2P.
+- Functional deploys the app to the functional namespace and runs functional tests as Helm tests.
+- Non-functional tests deploy the app to the NFT namespace and run K6 load tests as Helm tests when the NFT target is enabled.
+- Integration deploys the app to the integration namespace and runs integration tests as Helm tests.
+- Extended tests deploy the promoted image to the extended-test namespace and run longer-running validation.
+- Prod deploys the selected production candidate to the production namespace.
+
+### Configuration
+
+- `p2p/config/common.yaml` contains Helm values shared by all stages. It is rendered with environment variables before Helm receives it.
+- `p2p/config/functional.yaml` contains functional-stage overrides.
+- `p2p/config/nft.yaml` contains NFT-stage overrides.
+- `p2p/config/integration.yaml` contains integration-stage overrides.
+- `p2p/config/extended-test.yaml` contains extended-test-stage overrides.
+- `p2p/config/prod.yaml` contains production overrides.
+- Stage-specific files should only contain differences from `common.yaml`.
+
+### Tests
+
+- Unit and lint checks run before the app image is built.
+- Functional tests live in `p2p/tests/functional/` and validate externally visible app behavior with Cucumber and Playwright.
+- Non-functional tests live in `p2p/tests/nft/` and use K6 plus Prometheus validation for load-test thresholds.
+- Integration tests live in `p2p/tests/integration/` and validate behavior against deployed dependencies.
+- Extended tests live in `p2p/tests/extended/` and are intended for longer or higher-load validation than fast feedback.
+
+Keep generated P2P contract changes aligned across `Makefile`, `.github/workflows/`, `p2p/config/`, and `p2p/tests/`.

--- a/static/nextra/skeleton/README.md
+++ b/static/nextra/skeleton/README.md
@@ -1,206 +1,25 @@
 # {{ name }}
 
-Nextra docs application for Core Platform
+Static documentation site generated from the Core Platform `static-nextra` software template.
 
-# Parameters
+## Tech Stack
 
-Update main parameters of templates in `Makefile`:
+- Nextra documentation site built on Next.js and React.
+- Yarn-managed JavaScript dependencies.
+- Container image built from the generated `Dockerfile`.
+- Application traffic is served on port `3000`.
+- Metrics are served on port `8081`.
 
-- `app_name` - name of the application. it defines the name of the images produced by the Makefile targets, kubernetes resources, etc.
+## Application Endpoints
 
-# Path to Production (P2P)
+- `GET /` serves the documentation site.
+- `GET /readyz` reports readiness.
+- `GET /livez` reports liveness.
+- `GET /metrics` exposes Prometheus metrics.
 
-The P2P uses GitHub Actions to interact with the platform.
+## Project Layout
 
-As part of the P2P, using Hierarchical Namespace Controller, child namespaces will be created:
-
-- `<tenant-name>-functional`
-- `<tenant-name>-nft`
-- `<tenant-name>-integration`
-- `<tenant-name>-extended`
-
-The application is deployed to each of this following the shape:
-
-```
-| Build Service | -> | Functional testing | -> | NF testing | -> | Integration testing | -> | Promote image to Extended tests |
-```
-
-The tests are executed as helm tests. For that to work, each test phase is packaged in a docker image and pushed to a registry.
-It's then executed after the deployment of the respective environment to ensure the service is working correctly.
-
-You can run `make p2p-help` to list the available make targets.
-
-#### Requirements
-
-The interface between the P2P and the application is `Make`.
-For everything to work for you locally you need to ensure you have the following tools installed on your machine:
-
-- Make
-- Docker
-- Kubectl
-- Helm
-
-#### Prerequisites for local run
-
-To run the P2P locally, you need to connect to a cloud development environment.
-The easiest way to [do that is using `corectl`](https://docs.coreplatform.io/platform#using-corectl).
-
-Once connected, export all env variables required to run Makefile targets, see [Executing P2P targets Locally](https://docs.coreplatform.io/p2p/reference/p2p-locally)
-for instructions.
-
-#### Image Versioning
-
-The version is automatically generated when running the pipeline in GitHub Actions, but when you build the image
-locally using `p2p-build` you may need to specify `VERSION` when running `make` command.
-
-```
-make VERSION=1.0.0 p2p-build
-```
-
-#### Building on arm64
-
-If you are on `arm64` you may find that your Docker image is not starting on the target host. This may be because of
-the incompatible target platform architecture. You may explicitly require that the image is built for `linux/amd64` platform:
-
-```
-DOCKER_DEFAULT_PLATFORM="linux/amd64" make p2p-build
-```
-
-#### Push the image
-
-There's a shared tenant registry created `europe-west2-docker.pkg.dev/<project_id>/tenant`. You'll need to set your project_id and export this string as an environment variable called `REGISTRY`, for example:
-
-```
-export REGISTRY=europe-west2-docker.pkg.dev/<project_id>/tenant
-```
-
-#### Ingress URL construction
-
-For ingress to be configured correctly,
-you'll need to set up the environment that you want to deploy to, as well as the base url to be used.
-This must match one of the `ingress_domains` configured for that environment. For example, inside CECG we have an environment called `gcp-dev` that's ingress domain is set to `gcp-dev.cecg.platform.cecg.io`.
-
-This reference app assumes `<environment>.<domain>`, check with your deployment of the Core Platform if this is the case.
-
-This will construct the base URL as `<environment>.<domain>`, for example, `gcp-dev.cecg.platform.cecg.io`.
-
-```
-export BASE_DOMAIN=gcp-dev.cecg.platform.cecg.io
-```
-
-Read [more](https://docs.coreplatform.io/application/ingress) about Ingress.
-
-#### Logs
-
-You may find the results of the test runs in Grafana. The pipeline generates a link with the specific time range.
-
-To generate a correct link to Grafana you need to make sure you have `INTERNAL_SERVICES_DOMAIN` set up.
-
-```
-export INTERNAL_SERVICES_DOMAIN=gcp-dev-internal.cecg.platform.cecg.io
-```
-
-## Functional Testing
-
-Stubbed Functional Tests using [Cucumber JS](https://cucumber.io/docs/installation/javascript)
-
-This namespace is used to test the functionality of the app. Currently, using BDD (Behaviour driven development)
-
-## NFT
-
-This namespace is used to test how the service behaves under load, e.g. 1k TPS, P99 latency < 2000 ms for 1 minute run.
-
-There are 1 endpoint available for testing:
-
-- `/hello` - simply returns `Hello world`.
-
-## Integration Testing
-
-Integration Tests are using [Cucumber JS](https://cucumber.io/docs/installation/javascript)
-
-This namespace is used to test that the individual parts of the system as well as service-to-service communication
-of the app works correctly against real dependencies. Currently, using BDD (Behaviour driven development)
-
-#### Load Generation
-
-We are using [K6](https://k6.io/) to generate constant load, collect metrics and validate them against thresholds.
-
-There is a test examples: [hello.js](./resources/load-testing/hello.js)
-
-`helm test` runs K6 scenario in a single Pod.
-
-#### Platform Ingress
-
-We can send the traffic to the reference app either via ingress endpoint or directly via service endpoint.
-
-There is `nft.endpoint` parameter in `values.yaml` that can be set to `ingress` or `service`.
-
-## Extended test
-
-This is similar to NFT, but generates much higher load and runs longer, e.g. 10k TPS, P99 latency < 2000 ms for 10 minutes run.
-
-#### Load Generation
-
-We are using [K6](https://k6.io/) to generate the load.
-We are using [K6 Operator](https://github.com/grafana/k6-operator) to run multiple jobs in parallel, so that we can reach high
-TPS requirements.
-
-When running parallel jobs with K6 Operator we are not getting back the aggregated metrics at the end of the test.
-We are collecting the metrics with Prometheus and validating the results with `promtool`.
-
-#### Platform Ingress
-
-We can send the traffic to the reference app either via ingress endpoint or directly via service endpoint.
-See NFT section for more details.
-
-## Platform Features
-
-> Due to the restrictions applied to your platform you may not be able to enable some of the features
-
-### Monitoring
-
-This feature is needed to allow metrics collection by Prometheus. It needs the metric store (prometheus) to be installed on the parent namespace e.g. `TENANT_NAME`.
-
-By default, Monitoring is disabled. In order to enable it, you need to explicitly override the variable
-
-```
-make MONITORING=true p2p-nft
-```
-
-or change `MONITORING` to `true` in `Makefile`.
-
-### Dashboarding
-
-This feature allows you to automatically import dashboard definitions to Grafana.
-
-> You may import the dashboard manually by uploading the json definition via browser
-
-By default, `DASHBOARDING` is disabled. In order to enable it, you need to explicitly override the variable
-
-```
-make DASHBOARDING=true p2p-nft
-```
-
-or change `DASHBOARDING` to `true` in `Makefile`.
-
-The reference app comes with `10k TPS Reference App` dashboard that shows the TPS and latency
-for the load generator, ingress, API server and its downstream dependency.
-
-This feature depends on metrics collected by `Service Monitor`.
-
-### K6 Operator
-
-> K6 Operator must be enabled for the tenant to run the extended test
-
-You can enable it by enabling the beta feature in the tenant.yaml file:
-
-```yaml
-betaFeatures:
-  - k6-operator
-```
-
-## Limiting the CPU usage
-
-When running load tests it is important that we define CPU resource limits. This will allow us to have stable results between runs.
-
-If we don't apply the limits then the performance of the Pods will depend on the CPU utilization of the node that is running the container.
+- `src/app/` contains the Nextra application.
+- `content/` contains documentation content.
+- `p2p/` contains Core Platform deployment config and test containers.
+- `AGENTS.md` contains generated-repository guidance for coding agents.

--- a/tests/template_docs_test.sh
+++ b/tests/template_docs_test.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+app_templates=(
+  "docker/web"
+  "go/web"
+  "java/web"
+  "nextjs/web"
+  "python/web"
+  "static/nextra"
+)
+
+failures=0
+
+check_file_contains() {
+  local file=$1
+  local pattern=$2
+  local message=$3
+
+  if ! grep -qE "$pattern" "$file"; then
+    printf 'FAIL: %s: %s\n' "$file" "$message"
+    failures=$((failures + 1))
+  fi
+}
+
+check_file_not_contains() {
+  local file=$1
+  local pattern=$2
+  local message=$3
+
+  if grep -qE "$pattern" "$file"; then
+    printf 'FAIL: %s: %s\n' "$file" "$message"
+    failures=$((failures + 1))
+  fi
+}
+
+for template in "${app_templates[@]}"; do
+  agents_file="$template/skeleton/AGENTS.md"
+  readme_file="$template/skeleton/README.md"
+
+  if [[ ! -f "$agents_file" ]]; then
+    printf 'FAIL: %s missing generated AGENTS.md\n' "$template"
+    failures=$((failures + 1))
+    continue
+  fi
+
+  check_file_contains "$agents_file" '^## Template And Tech Stack$' "missing template/tech stack section"
+  check_file_contains "$agents_file" '^## Core Platform P2P$' "missing standard P2P section"
+  check_file_contains "$agents_file" 'fast-feedback.yaml' "must document fast feedback workflow"
+  check_file_contains "$agents_file" 'p2p/config/common.yaml' "must document common config"
+  check_file_contains "$agents_file" 'p2p/config/functional.yaml' "must document functional config"
+  check_file_contains "$agents_file" 'Functional tests' "must document functional tests"
+  check_file_contains "$agents_file" 'Non-functional tests' "must document NFT tests"
+  check_file_contains "$agents_file" 'Integration tests' "must document integration tests"
+  check_file_contains "$agents_file" 'Extended tests' "must document extended tests"
+  check_file_not_contains "$agents_file" 'local P2P|run the P2P locally|Executing P2P targets Locally|corectl' "must not document local P2P execution"
+
+  check_file_not_contains "$readme_file" 'Path to Production|P2P Overview|Core Platform P2P|Functional Testing|Non-Functional Testing|Integration Testing|Extended Testing|## NFT|## Extended test' "README should not explain P2P/test stages"
+done
+
+monitoring_agents="monitoring-stack/skeleton/AGENTS.md"
+monitoring_readme="monitoring-stack/skeleton/README.md"
+
+if [[ ! -f "$monitoring_agents" ]]; then
+  printf 'FAIL: monitoring-stack missing generated AGENTS.md\n'
+  failures=$((failures + 1))
+else
+  check_file_contains "$monitoring_agents" '^## Template And Tech Stack$' "missing monitoring template/tech stack section"
+  check_file_contains "$monitoring_agents" '^## Core Platform P2P$' "missing monitoring P2P section"
+  check_file_contains "$monitoring_agents" 'integration.yaml' "must document integration config"
+  check_file_contains "$monitoring_agents" 'prod.yaml' "must document prod config"
+  check_file_not_contains "$monitoring_agents" 'Functional tests|Non-functional tests|Extended tests|local P2P|corectl' "monitoring AGENTS should stay monitoring-specific"
+fi
+
+check_file_contains "$monitoring_readme" 'p2p/config/integration.yaml' "README should document integration monitored delivery units"
+check_file_contains "$monitoring_readme" 'p2p/config/prod.yaml' "README should document prod monitored delivery units"
+check_file_not_contains "$monitoring_readme" 'Functional Testing|Non-Functional Testing|Extended Testing|## NFT|local P2P|corectl' "monitoring README should not contain app P2P guidance"
+
+if [[ "$failures" -gt 0 ]]; then
+  exit 1
+fi
+
+printf 'Template documentation checks passed\n'


### PR DESCRIPTION
## Summary

- Add generated `AGENTS.md` files for app templates with template-specific stack notes and Core Platform P2P guidance.
- Trim generated READMEs down to template-specific documentation.
- Keep `monitoring-stack` README focused on monitored delivery units and add a monitoring-specific `AGENTS.md`.
- Add a template documentation contract test to `templates-validate`.

## Verification

- `make templates-validate`