### PR TITLE
Make Cloud SQL private networking optional

### DIFF
--- a/infra/cloudsql/skeleton/README.md
+++ b/infra/cloudsql/skeleton/README.md
@@ -24,8 +24,8 @@ Collect these values before enabling the pipeline:
 
 The template uses two project IDs:
 
-- `platform_project_id`: the Core Platform environment project that consumes the database through Private Service Connect.
-- `infrastructure_project_id`: the tenant-owned GCP project where this template creates Cloud SQL, the PSA network, monitoring resources, and Terraform state.
+- `platform_project_id`: the Core Platform environment project that runs applications connecting to the database.
+- `infrastructure_project_id`: the tenant-owned GCP project where this template creates Cloud SQL, monitoring resources, and Terraform state.
 
 The `infrastructure_project_id` project must already exist, have billing enabled, and allow the P2P deploy identity to manage resources. Terragrunt stores state in a bucket named `tfstate-<infrastructure_project_id>`.
 
@@ -132,3 +132,16 @@ Terragrunt skips provisioning until all required bootstrap values are present:
 - `platform_project_id`
 
 Cloud SQL resources are only created when `cloudsql.enabled` is `true` and at least one PostgreSQL cluster is configured.
+
+## Network Defaults
+
+Generated Cloud SQL instances use public IP by default with Cloud SQL connector enforcement enabled. Applications should connect through a Cloud SQL connector or Cloud SQL Auth Proxy, and access can be narrowed with `cloudsql.allowed_ip_ranges`.
+
+Private networking is opt-in:
+
+- Set `cloudsql.psa_enabled: true` to create a dedicated Private Service Access VPC and attach instances to it.
+- Set `cloudsql.psc_enabled: true` to enable Private Service Connect producer-side settings for the platform project.
+- Set cluster `public_ip_enabled: false` only when `cloudsql.psa_enabled` or `cloudsql.psc_enabled` is also enabled.
+- Set `cloudsql.ids.enabled: true` only with `cloudsql.psa_enabled: true`; Cloud IDS mirrors the PSA VPC.
+
+Do not enable PSC unless the consuming platform environment also provides the required PSC consumer endpoint and DNS. Without that platform-side setup, PSC-only clients cannot resolve or reach the Cloud SQL instance.

--- a/infra/cloudsql/skeleton/infrastructure/code/cloudsql.tf
+++ b/infra/cloudsql/skeleton/infrastructure/code/cloudsql.tf
@@ -2,6 +2,8 @@ variable "cloudsql" {
   description = "Cloud SQL configuration"
   type = object({
     enabled           = bool
+    psa_enabled       = optional(bool, false)
+    psc_enabled       = optional(bool, false)
     allowed_ip_ranges = optional(list(map(string)), [])
     monitoring = optional(object({
       notification_emails = optional(list(string), [])
@@ -89,6 +91,19 @@ variable "cloudsql" {
   validation {
     condition     = contains(["INFORMATIONAL", "LOW", "MEDIUM"], try(var.cloudsql.ids.severity, "INFORMATIONAL"))
     error_message = "cloudsql.ids.severity must be INFORMATIONAL, LOW, or MEDIUM."
+  }
+
+  validation {
+    condition     = !try(var.cloudsql.ids.enabled, false) || try(var.cloudsql.psa_enabled, false)
+    error_message = "cloudsql.ids.enabled requires cloudsql.psa_enabled because Cloud IDS mirrors the PSA VPC."
+  }
+
+  validation {
+    condition = alltrue([
+      for cluster in try(var.cloudsql.clusters.postgresql, []) :
+      try(cluster.public_ip_enabled, true) || try(var.cloudsql.psa_enabled, false) || try(var.cloudsql.psc_enabled, false)
+    ])
+    error_message = "Cloud SQL clusters with public_ip_enabled=false require cloudsql.psa_enabled or cloudsql.psc_enabled."
   }
 }
 

--- a/infra/cloudsql/skeleton/infrastructure/code/modules/cloudsql/README.md
+++ b/infra/cloudsql/skeleton/infrastructure/code/modules/cloudsql/README.md
@@ -6,8 +6,8 @@ It wraps the official [terraform-google-sql-db PostgreSQL module](https://github
 
 ## Module Features
 
-- **Private Service Access (PSA)**: Automatic VPC network and PSA setup for private connectivity
-- **Private Service Connect (PSC)**: Enabled for secure cross-project database access
+- **Private Service Access (PSA)**: Optional VPC network and PSA setup for private connectivity
+- **Private Service Connect (PSC)**: Optional producer-side settings for cross-project database access
 - **High Availability**: Support for regional (HA) or zonal deployments
 - **Comprehensive Backup**: Point-in-time recovery (PITR) with configurable retention
 - **Security First**: Encrypted connections only, deletion protection by default, password validation policies
@@ -19,10 +19,9 @@ It wraps the official [terraform-google-sql-db PostgreSQL module](https://github
 ## Architecture
 
 The module creates:
-1. A dedicated VPC network for Cloud SQL Private Service Access
-2. Private Service Access connection to Google Cloud SQL service producer
-3. One or more PostgreSQL instances (defined via `for_each`)
-4. Databases, users, and IAM bindings as configured
+1. One or more PostgreSQL instances (defined via `for_each`)
+2. Databases, users, and IAM bindings as configured
+3. Optional dedicated VPC network and Private Service Access connection when `cloudsql.psa_enabled` is true
 
 ## Input Variables
 
@@ -42,6 +41,8 @@ The module creates:
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `enabled` | `bool` | (required) | Whether to create Cloud SQL resources |
+| `psa_enabled` | `bool` | `false` | Whether to create a dedicated Private Service Access VPC and attach instances to it |
+| `psc_enabled` | `bool` | `false` | Whether to enable Cloud SQL producer-side Private Service Connect settings for the platform project |
 | `allowed_ip_ranges` | `list(map(string))` | `[]` | List of authorized networks for public IP access. Each entry should have `name` and `value` (CIDR) |
 
 #### Monitoring Configuration
@@ -140,7 +141,7 @@ If near zero downtime planned maintenance is required please consult Google's [d
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `connector_enforcement` | `bool` | `true` | Enforce that clients use the connector library |
-| `public_ip_enabled` | `bool` | `true` | Enable public IPv4 address for the instance. When `false`, the instance is only accessible via private IP through VPC/PSA, which requires network connectivity to the private network (e.g., VPN, or running from within GCP). The `cloud-sql-proxy` command must include the `--private-ip` flag when public IP is disabled. |
+| `public_ip_enabled` | `bool` | `true` | Enable public IPv4 address for the instance. When `false`, `cloudsql.psa_enabled` or `cloudsql.psc_enabled` must be true and clients need the corresponding private connectivity. |
 | `deletion_protection` | `bool` | `true` | Enables protection of an Cloud SQL instance from accidental deletion across all surfaces (API, gcloud, Cloud Console and Terraform) |
 | `database_deletion_policy` | `string` | `"ABANDON"` | The deletion policy for the database, `ABANDON` is useful for PostgreSQL where databases cannot be deleted from the API if there are users other than cloudsqlsuperuser with access |
 | `retain_backups_on_delete` | `bool` | `false` | When this parameter is set to true, Cloud SQL retains backups of the instance even after the instance is deleted. The ON_DEMAND backup will be retained until customer deletes the backup or the project. The AUTOMATED backup will be retained based on the backups retention setting. |
@@ -168,9 +169,13 @@ The module automatically configures audit logging using [pgAudit](https://www.pg
 
 ### Private Service Access (PSA)
 
-The module automatically creates:
+When `cloudsql.psa_enabled` is true, the module creates:
 - A dedicated VPC network: `cloudsql-{environment}-psa`
 - Private Service Access connection with address `10.220.0.0/16`
+
+### Private Service Connect (PSC)
+
+When `cloudsql.psc_enabled` is true, the module enables Cloud SQL producer-side PSC settings and allows the configured platform project as a consumer. The consuming platform environment must still provide the PSC consumer endpoint and DNS before clients can use PSC.
 
 ### IP Configuration
 
@@ -180,19 +185,17 @@ The module configures the following network settings:
 ip_configuration = {
   ssl_mode                      = "ENCRYPTED_ONLY"     # Force SSL/TLS (hardcoded)
   authorized_networks           = var.cloudsql.allowed_ip_ranges
-  ipv4_enabled                  = each.value.public_ip_enabled  # Configurable, defaults to false
-  private_network               = google_compute_network.psa.id # PSA network (hardcoded)
-  psc_enabled                   = true                 # Private Service Connect (hardcoded)
-  psc_allowed_consumer_projects = [platform_project_id]  # (hardcoded)
+  ipv4_enabled                  = each.value.public_ip_enabled  # Configurable, defaults to true
+  private_network               = local.psa_enabled ? google_compute_network.psa[0].id : null
+  psc_enabled                   = local.psc_enabled
+  psc_allowed_consumer_projects = local.psc_enabled ? [platform_project_id] : []
 }
 ```
 
 **Notes**:
-- With `public_ip_enabled = true` (default), the instance has both public and private IPs. Connector enforcement still ensures secure connections.
-- With `public_ip_enabled = false`, the instance only has a private IP, providing maximum security but requiring:
-  - Network connectivity to the private IP range (10.220.0.0/16) via VPN, Cloud VPN, or running from within GCP
-  - The `--private-ip` flag when using `cloud-sql-proxy` command
-  - Terraform provisioner must run from a location with private network access
+- With `public_ip_enabled = true` (default), applications can connect through a Cloud SQL connector or Cloud SQL Auth Proxy. Connector enforcement still ensures secure connections.
+- With `public_ip_enabled = false`, either PSA or PSC must be enabled and clients must use the matching private connectivity path.
+- Cloud IDS requires PSA because it mirrors the PSA VPC.
 
 ## User Management
 

--- a/infra/cloudsql/skeleton/infrastructure/code/modules/cloudsql/cloud_ids.tf
+++ b/infra/cloudsql/skeleton/infrastructure/code/modules/cloudsql/cloud_ids.tf
@@ -22,7 +22,7 @@ resource "google_cloud_ids_endpoint" "psa" {
   project  = var.infrastructure_project_id
   name     = "cloudsql-${var.environment}-ids"
   location = local.cloud_ids_location
-  network  = google_compute_network.psa.id
+  network  = google_compute_network.psa[0].id
   severity = local.cloud_ids_severity
 
   depends_on = [google_project_service.cloud_ids, module.cloudsql-psa]
@@ -36,7 +36,7 @@ resource "google_compute_packet_mirroring" "psa" {
   name    = "cloudsql-${var.environment}-ids-mirroring"
 
   network {
-    url = google_compute_network.psa.id
+    url = google_compute_network.psa[0].id
   }
 
   collector_ilb {

--- a/infra/cloudsql/skeleton/infrastructure/code/modules/cloudsql/locals.tf
+++ b/infra/cloudsql/skeleton/infrastructure/code/modules/cloudsql/locals.tf
@@ -46,7 +46,9 @@ locals {
     for channel in google_monitoring_notification_channel.cloudsql_email : channel.name
   ]
 
-  cloud_ids_enabled               = try(var.cloudsql.ids.enabled, false)
+  psa_enabled                     = try(var.cloudsql.psa_enabled, false)
+  psc_enabled                     = try(var.cloudsql.psc_enabled, false)
+  cloud_ids_enabled               = try(var.cloudsql.ids.enabled, false) && local.psa_enabled
   cloud_ids_location              = coalesce(try(var.cloudsql.ids.location, null), "${var.region}-b")
   cloud_ids_severity              = try(var.cloudsql.ids.severity, "INFORMATIONAL")
   cloud_ids_packet_mirroring_tags = try(var.cloudsql.ids.packet_mirroring_tags, ["cloudsql-psa"])

--- a/infra/cloudsql/skeleton/infrastructure/code/modules/cloudsql/main.tf
+++ b/infra/cloudsql/skeleton/infrastructure/code/modules/cloudsql/main.tf
@@ -10,6 +10,8 @@ resource "random_password" "cloudsql_initial_password" {
 }
 
 resource "google_compute_network" "psa" {
+  count = local.psa_enabled ? 1 : 0
+
   name                    = "cloudsql-${var.environment}-psa"
   project                 = var.infrastructure_project_id
   auto_create_subnetworks = false
@@ -18,12 +20,14 @@ resource "google_compute_network" "psa" {
 }
 
 module "cloudsql-psa" {
+  count = local.psa_enabled ? 1 : 0
+
   source  = "terraform-google-modules/sql-db/google//modules/private_service_access"
   version = "26.2.2"
 
   depends_on  = [module.project-services, google_compute_network.psa]
   project_id  = var.infrastructure_project_id
-  vpc_network = google_compute_network.psa.name
+  vpc_network = google_compute_network.psa[0].name
   address     = "10.220.0.0"
 }
 
@@ -72,9 +76,9 @@ module "cloudsql-postgresql" {
     ssl_mode                      = "ENCRYPTED_ONLY"
     authorized_networks           = var.cloudsql.allowed_ip_ranges
     ipv4_enabled                  = each.value.public_ip_enabled
-    private_network               = google_compute_network.psa.id
-    psc_enabled                   = true
-    psc_allowed_consumer_projects = [data.google_project.platform_project.number]
+    private_network               = local.psa_enabled ? google_compute_network.psa[0].id : null
+    psc_enabled                   = local.psc_enabled
+    psc_allowed_consumer_projects = local.psc_enabled ? [data.google_project.platform_project.number] : []
   }
 
   backup_configuration = {

--- a/infra/cloudsql/skeleton/infrastructure/code/modules/cloudsql/variables.tf
+++ b/infra/cloudsql/skeleton/infrastructure/code/modules/cloudsql/variables.tf
@@ -18,6 +18,8 @@ variable "cloudsql" {
   description = "Cloud SQL configuration"
   type = object({
     enabled           = bool
+    psa_enabled       = optional(bool, false)
+    psc_enabled       = optional(bool, false)
     allowed_ip_ranges = optional(list(map(string)), [])
     monitoring = optional(object({
       notification_emails = optional(list(string), [])
@@ -105,5 +107,18 @@ variable "cloudsql" {
   validation {
     condition     = contains(["INFORMATIONAL", "LOW", "MEDIUM"], try(var.cloudsql.ids.severity, "INFORMATIONAL"))
     error_message = "cloudsql.ids.severity must be INFORMATIONAL, LOW, or MEDIUM."
+  }
+
+  validation {
+    condition     = !try(var.cloudsql.ids.enabled, false) || try(var.cloudsql.psa_enabled, false)
+    error_message = "cloudsql.ids.enabled requires cloudsql.psa_enabled because Cloud IDS mirrors the PSA VPC."
+  }
+
+  validation {
+    condition = alltrue([
+      for cluster in try(var.cloudsql.clusters.postgresql, []) :
+      try(cluster.public_ip_enabled, true) || try(var.cloudsql.psa_enabled, false) || try(var.cloudsql.psc_enabled, false)
+    ])
+    error_message = "Cloud SQL clusters with public_ip_enabled=false require cloudsql.psa_enabled or cloudsql.psc_enabled."
   }
 }


### PR DESCRIPTION
## Summary
- make Cloud SQL PSA and PSC explicit opt-in settings in the infra template
- default generated Cloud SQL instances to public IP with connector enforcement
- validate Cloud IDS/public-IP-off combinations so generated configs fail early
- update generated docs for PSA/PSC requirements

## Checks
- tofu fmt -recursive
- tofu init -backend=false
- tofu validate
- git diff --check