### PR TITLE
Support per-cluster Cloud SQL connectivity

### DIFF
--- a/infra/cloudsql/skeleton/infrastructure/code/cloudsql.tf
+++ b/infra/cloudsql/skeleton/infrastructure/code/cloudsql.tf
@@ -28,6 +28,8 @@ variable "cloudsql" {
         tier               = string
         database_version   = string
         edition            = optional(string, "ENTERPRISE")
+        psa_enabled        = optional(bool)
+        psc_enabled        = optional(bool)
         activation_policy  = optional(string, "ALWAYS")
         data_cache_enabled = optional(bool, false)
         databases = list(object({
@@ -101,9 +103,9 @@ variable "cloudsql" {
   validation {
     condition = alltrue([
       for cluster in try(var.cloudsql.clusters.postgresql, []) :
-      try(cluster.public_ip_enabled, true) || try(var.cloudsql.psa_enabled, false) || try(var.cloudsql.psc_enabled, false)
+      try(cluster.public_ip_enabled, true) || coalesce(try(cluster.psa_enabled, null), try(var.cloudsql.psa_enabled, false)) || coalesce(try(cluster.psc_enabled, null), try(var.cloudsql.psc_enabled, false))
     ])
-    error_message = "Cloud SQL clusters with public_ip_enabled=false require cloudsql.psa_enabled or cloudsql.psc_enabled."
+    error_message = "Cloud SQL clusters with public_ip_enabled=false require psa_enabled or psc_enabled at the cluster or cloudsql level."
   }
 }
 

--- a/infra/cloudsql/skeleton/infrastructure/code/modules/cloudsql/locals.tf
+++ b/infra/cloudsql/skeleton/infrastructure/code/modules/cloudsql/locals.tf
@@ -48,6 +48,9 @@ locals {
 
   psa_enabled                     = try(var.cloudsql.psa_enabled, false)
   psc_enabled                     = try(var.cloudsql.psc_enabled, false)
+  cluster_psa_enabled             = { for name, cluster in local.postgresql_clusters_map : name => coalesce(try(cluster.psa_enabled, null), local.psa_enabled) }
+  cluster_psc_enabled             = { for name, cluster in local.postgresql_clusters_map : name => coalesce(try(cluster.psc_enabled, null), local.psc_enabled) }
+  any_psa_enabled                 = anytrue(values(local.cluster_psa_enabled))
   cloud_ids_enabled               = try(var.cloudsql.ids.enabled, false) && local.psa_enabled
   cloud_ids_location              = coalesce(try(var.cloudsql.ids.location, null), "${var.region}-b")
   cloud_ids_severity              = try(var.cloudsql.ids.severity, "INFORMATIONAL")

--- a/infra/cloudsql/skeleton/infrastructure/code/modules/cloudsql/main.tf
+++ b/infra/cloudsql/skeleton/infrastructure/code/modules/cloudsql/main.tf
@@ -10,7 +10,7 @@ resource "random_password" "cloudsql_initial_password" {
 }
 
 resource "google_compute_network" "psa" {
-  count = local.psa_enabled ? 1 : 0
+  count = local.any_psa_enabled ? 1 : 0
 
   name                    = "cloudsql-${var.environment}-psa"
   project                 = var.infrastructure_project_id
@@ -20,7 +20,7 @@ resource "google_compute_network" "psa" {
 }
 
 module "cloudsql-psa" {
-  count = local.psa_enabled ? 1 : 0
+  count = local.any_psa_enabled ? 1 : 0
 
   source  = "terraform-google-modules/sql-db/google//modules/private_service_access"
   version = "26.2.2"
@@ -76,9 +76,9 @@ module "cloudsql-postgresql" {
     ssl_mode                      = "ENCRYPTED_ONLY"
     authorized_networks           = var.cloudsql.allowed_ip_ranges
     ipv4_enabled                  = each.value.public_ip_enabled
-    private_network               = local.psa_enabled ? google_compute_network.psa[0].id : null
-    psc_enabled                   = local.psc_enabled
-    psc_allowed_consumer_projects = local.psc_enabled ? [data.google_project.platform_project.number] : []
+    private_network               = local.cluster_psa_enabled[each.key] ? google_compute_network.psa[0].id : null
+    psc_enabled                   = local.cluster_psc_enabled[each.key]
+    psc_allowed_consumer_projects = local.cluster_psc_enabled[each.key] ? [data.google_project.platform_project.number] : []
   }
 
   backup_configuration = {

--- a/infra/cloudsql/skeleton/infrastructure/code/modules/cloudsql/variables.tf
+++ b/infra/cloudsql/skeleton/infrastructure/code/modules/cloudsql/variables.tf
@@ -44,6 +44,8 @@ variable "cloudsql" {
         tier               = string
         database_version   = string
         edition            = optional(string, "ENTERPRISE")
+        psa_enabled        = optional(bool)
+        psc_enabled        = optional(bool)
         activation_policy  = optional(string, "ALWAYS")
         data_cache_enabled = optional(bool, false)
         databases = list(object({
@@ -117,8 +119,8 @@ variable "cloudsql" {
   validation {
     condition = alltrue([
       for cluster in try(var.cloudsql.clusters.postgresql, []) :
-      try(cluster.public_ip_enabled, true) || try(var.cloudsql.psa_enabled, false) || try(var.cloudsql.psc_enabled, false)
+      try(cluster.public_ip_enabled, true) || coalesce(try(cluster.psa_enabled, null), try(var.cloudsql.psa_enabled, false)) || coalesce(try(cluster.psc_enabled, null), try(var.cloudsql.psc_enabled, false))
     ])
-    error_message = "Cloud SQL clusters with public_ip_enabled=false require cloudsql.psa_enabled or cloudsql.psc_enabled."
+    error_message = "Cloud SQL clusters with public_ip_enabled=false require psa_enabled or psc_enabled at the cluster or cloudsql level."
   }
 }


### PR DESCRIPTION
## Summary
- add optional per-cluster Cloud SQL PSA/PSC overrides to the infra CloudSQL template
- preserve existing top-level cloudsql PSA/PSC settings as defaults
- create the PSA network when any cluster resolves to PSA enabled

## Validation
- tofu fmt -check infra/cloudsql/skeleton/infrastructure/code/cloudsql.tf infra/cloudsql/skeleton/infrastructure/code/modules/cloudsql/variables.tf infra/cloudsql/skeleton/infrastructure/code/modules/cloudsql/locals.tf infra/cloudsql/skeleton/infrastructure/code/modules/cloudsql/main.tf
- git diff --check

No generated p2p config changes included.