### PR TITLE
Add Cloud SQL PSA resource management toggle

### DIFF
--- a/infra/cloudsql/skeleton/README.md
+++ b/infra/cloudsql/skeleton/README.md
@@ -140,7 +140,7 @@ Generated Cloud SQL instances use public IP by default with Cloud SQL connector 
 Private networking is opt-in:
 
 - Set `cloudsql.psa_enabled: true` to attach instances to the dedicated Private Service Access VPC.
-- Leave `cloudsql.manage_psa_resources` unset for normal PSA use. Set it to `false` only for transitional cleanup where Cloud SQL must keep existing PSA `private_network` metadata but Terraform must not create or manage the PSA VPC resources.
+- Leave `cloudsql.manage_psa_resources` unset for normal PSA use. Set it to `false` when attaching Cloud SQL instances to an existing PSA VPC and private service access connection managed outside this infra app, for example when multiple infra apps share one PSA setup in the same project.
 - Set `cloudsql.psc_enabled: true` to enable Private Service Connect producer-side settings for the platform project.
 - Set cluster `public_ip_enabled: false` only when `cloudsql.psa_enabled` or `cloudsql.psc_enabled` is also enabled.
 - Set `cloudsql.ids.enabled: true` only with managed PSA resources; Cloud IDS mirrors the PSA VPC.

--- a/infra/cloudsql/skeleton/README.md
+++ b/infra/cloudsql/skeleton/README.md
@@ -139,9 +139,10 @@ Generated Cloud SQL instances use public IP by default with Cloud SQL connector 
 
 Private networking is opt-in:
 
-- Set `cloudsql.psa_enabled: true` to create a dedicated Private Service Access VPC and attach instances to it.
+- Set `cloudsql.psa_enabled: true` to attach instances to the dedicated Private Service Access VPC.
+- Leave `cloudsql.manage_psa_resources` unset for normal PSA use. Set it to `false` only for transitional cleanup where Cloud SQL must keep existing PSA `private_network` metadata but Terraform must not create or manage the PSA VPC resources.
 - Set `cloudsql.psc_enabled: true` to enable Private Service Connect producer-side settings for the platform project.
 - Set cluster `public_ip_enabled: false` only when `cloudsql.psa_enabled` or `cloudsql.psc_enabled` is also enabled.
-- Set `cloudsql.ids.enabled: true` only with `cloudsql.psa_enabled: true`; Cloud IDS mirrors the PSA VPC.
+- Set `cloudsql.ids.enabled: true` only with managed PSA resources; Cloud IDS mirrors the PSA VPC.
 
 Do not enable PSC unless the consuming platform environment also provides the required PSC consumer endpoint and DNS. Without that platform-side setup, PSC-only clients cannot resolve or reach the Cloud SQL instance.

--- a/infra/cloudsql/skeleton/infrastructure/code/cloudsql.tf
+++ b/infra/cloudsql/skeleton/infrastructure/code/cloudsql.tf
@@ -1,10 +1,11 @@
 variable "cloudsql" {
   description = "Cloud SQL configuration"
   type = object({
-    enabled           = bool
-    psa_enabled       = optional(bool, false)
-    psc_enabled       = optional(bool, false)
-    allowed_ip_ranges = optional(list(map(string)), [])
+    enabled              = bool
+    psa_enabled          = optional(bool, false)
+    manage_psa_resources = optional(bool)
+    psc_enabled          = optional(bool, false)
+    allowed_ip_ranges    = optional(list(map(string)), [])
     monitoring = optional(object({
       notification_emails = optional(list(string), [])
       thresholds = optional(object({
@@ -96,8 +97,8 @@ variable "cloudsql" {
   }
 
   validation {
-    condition     = !try(var.cloudsql.ids.enabled, false) || try(var.cloudsql.psa_enabled, false)
-    error_message = "cloudsql.ids.enabled requires cloudsql.psa_enabled because Cloud IDS mirrors the PSA VPC."
+    condition     = !try(var.cloudsql.ids.enabled, false) || (try(var.cloudsql.psa_enabled, false) && coalesce(try(var.cloudsql.manage_psa_resources, null), true))
+    error_message = "cloudsql.ids.enabled requires cloudsql.psa_enabled and managed PSA resources because Cloud IDS mirrors the PSA VPC."
   }
 
   validation {

--- a/infra/cloudsql/skeleton/infrastructure/code/modules/cloudsql/README.md
+++ b/infra/cloudsql/skeleton/infrastructure/code/modules/cloudsql/README.md
@@ -42,7 +42,7 @@ The module creates:
 |-----------|------|---------|-------------|
 | `enabled` | `bool` | (required) | Whether to create Cloud SQL resources |
 | `psa_enabled` | `bool` | `false` | Whether to attach instances to the dedicated Private Service Access VPC |
-| `manage_psa_resources` | `bool` | `cloudsql.psa_enabled` | Whether Terraform should create/manage the dedicated Private Service Access VPC, reserved range, and service networking connection. Set to `false` only for transitional environments where Cloud SQL must keep its existing `private_network` metadata but the PSA VPC is intentionally unmanaged. |
+| `manage_psa_resources` | `bool` | `cloudsql.psa_enabled` | Whether this module should create/manage the dedicated Private Service Access VPC, reserved range, and service networking connection. Set to `false` when attaching instances to an existing PSA VPC managed elsewhere, for example when multiple infra apps share one PSA setup in the same project. |
 | `psc_enabled` | `bool` | `false` | Whether to enable Cloud SQL producer-side Private Service Connect settings for the platform project |
 | `allowed_ip_ranges` | `list(map(string))` | `[]` | List of authorized networks for public IP access. Each entry should have `name` and `value` (CIDR) |
 
@@ -174,7 +174,7 @@ When `cloudsql.psa_enabled` is true and `cloudsql.manage_psa_resources` is not f
 - A dedicated VPC network: `cloudsql-{environment}-psa`
 - Private Service Access connection with address `10.220.0.0/16`
 
-When `cloudsql.psa_enabled` is true and `cloudsql.manage_psa_resources` is false, the module keeps Cloud SQL `private_network` set to the expected PSA VPC URI but does not create, read, or manage the PSA VPC resources. This is intended only for transitional cleanup of existing environments where removing `private_network` would force Cloud SQL replacement.
+When `cloudsql.psa_enabled` is true and `cloudsql.manage_psa_resources` is false, the module attaches Cloud SQL to the expected PSA VPC URI but does not create, read, or manage the PSA VPC resources. Use this when the PSA VPC and private service access connection are provided by another infra app or shared project setup.
 
 ### Private Service Connect (PSC)
 

--- a/infra/cloudsql/skeleton/infrastructure/code/modules/cloudsql/README.md
+++ b/infra/cloudsql/skeleton/infrastructure/code/modules/cloudsql/README.md
@@ -21,7 +21,7 @@ It wraps the official [terraform-google-sql-db PostgreSQL module](https://github
 The module creates:
 1. One or more PostgreSQL instances (defined via `for_each`)
 2. Databases, users, and IAM bindings as configured
-3. Optional dedicated VPC network and Private Service Access connection when `cloudsql.psa_enabled` is true
+3. Optional dedicated VPC network and Private Service Access connection when `cloudsql.psa_enabled` and `cloudsql.manage_psa_resources` are true
 
 ## Input Variables
 
@@ -41,7 +41,8 @@ The module creates:
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `enabled` | `bool` | (required) | Whether to create Cloud SQL resources |
-| `psa_enabled` | `bool` | `false` | Whether to create a dedicated Private Service Access VPC and attach instances to it |
+| `psa_enabled` | `bool` | `false` | Whether to attach instances to the dedicated Private Service Access VPC |
+| `manage_psa_resources` | `bool` | `cloudsql.psa_enabled` | Whether Terraform should create/manage the dedicated Private Service Access VPC, reserved range, and service networking connection. Set to `false` only for transitional environments where Cloud SQL must keep its existing `private_network` metadata but the PSA VPC is intentionally unmanaged. |
 | `psc_enabled` | `bool` | `false` | Whether to enable Cloud SQL producer-side Private Service Connect settings for the platform project |
 | `allowed_ip_ranges` | `list(map(string))` | `[]` | List of authorized networks for public IP access. Each entry should have `name` and `value` (CIDR) |
 
@@ -169,9 +170,11 @@ The module automatically configures audit logging using [pgAudit](https://www.pg
 
 ### Private Service Access (PSA)
 
-When `cloudsql.psa_enabled` is true, the module creates:
+When `cloudsql.psa_enabled` is true and `cloudsql.manage_psa_resources` is not false, the module creates:
 - A dedicated VPC network: `cloudsql-{environment}-psa`
 - Private Service Access connection with address `10.220.0.0/16`
+
+When `cloudsql.psa_enabled` is true and `cloudsql.manage_psa_resources` is false, the module keeps Cloud SQL `private_network` set to the expected PSA VPC URI but does not create, read, or manage the PSA VPC resources. This is intended only for transitional cleanup of existing environments where removing `private_network` would force Cloud SQL replacement.
 
 ### Private Service Connect (PSC)
 
@@ -186,7 +189,7 @@ ip_configuration = {
   ssl_mode                      = "ENCRYPTED_ONLY"     # Force SSL/TLS (hardcoded)
   authorized_networks           = var.cloudsql.allowed_ip_ranges
   ipv4_enabled                  = each.value.public_ip_enabled  # Configurable, defaults to true
-  private_network               = local.psa_enabled ? google_compute_network.psa[0].id : null
+  private_network               = local.psa_enabled ? local.psa_network_id : null
   psc_enabled                   = local.psc_enabled
   psc_allowed_consumer_projects = local.psc_enabled ? [platform_project_id] : []
 }
@@ -195,7 +198,7 @@ ip_configuration = {
 **Notes**:
 - With `public_ip_enabled = true` (default), applications can connect through a Cloud SQL connector or Cloud SQL Auth Proxy. Connector enforcement still ensures secure connections.
 - With `public_ip_enabled = false`, either PSA or PSC must be enabled and clients must use the matching private connectivity path.
-- Cloud IDS requires PSA because it mirrors the PSA VPC.
+- Cloud IDS requires managed PSA resources because it mirrors the PSA VPC.
 
 ## User Management
 

--- a/infra/cloudsql/skeleton/infrastructure/code/modules/cloudsql/locals.tf
+++ b/infra/cloudsql/skeleton/infrastructure/code/modules/cloudsql/locals.tf
@@ -51,7 +51,9 @@ locals {
   cluster_psa_enabled             = { for name, cluster in local.postgresql_clusters_map : name => coalesce(try(cluster.psa_enabled, null), local.psa_enabled) }
   cluster_psc_enabled             = { for name, cluster in local.postgresql_clusters_map : name => coalesce(try(cluster.psc_enabled, null), local.psc_enabled) }
   any_psa_enabled                 = anytrue(values(local.cluster_psa_enabled))
-  cloud_ids_enabled               = try(var.cloudsql.ids.enabled, false) && local.psa_enabled
+  manage_psa_resources            = coalesce(try(var.cloudsql.manage_psa_resources, null), local.any_psa_enabled)
+  psa_network_id                  = "projects/${var.infrastructure_project_id}/global/networks/cloudsql-${var.environment}-psa"
+  cloud_ids_enabled               = try(var.cloudsql.ids.enabled, false) && local.psa_enabled && local.manage_psa_resources
   cloud_ids_location              = coalesce(try(var.cloudsql.ids.location, null), "${var.region}-b")
   cloud_ids_severity              = try(var.cloudsql.ids.severity, "INFORMATIONAL")
   cloud_ids_packet_mirroring_tags = try(var.cloudsql.ids.packet_mirroring_tags, ["cloudsql-psa"])

--- a/infra/cloudsql/skeleton/infrastructure/code/modules/cloudsql/main.tf
+++ b/infra/cloudsql/skeleton/infrastructure/code/modules/cloudsql/main.tf
@@ -10,7 +10,7 @@ resource "random_password" "cloudsql_initial_password" {
 }
 
 resource "google_compute_network" "psa" {
-  count = local.any_psa_enabled ? 1 : 0
+  count = local.any_psa_enabled && local.manage_psa_resources ? 1 : 0
 
   name                    = "cloudsql-${var.environment}-psa"
   project                 = var.infrastructure_project_id
@@ -20,7 +20,7 @@ resource "google_compute_network" "psa" {
 }
 
 module "cloudsql-psa" {
-  count = local.any_psa_enabled ? 1 : 0
+  count = local.any_psa_enabled && local.manage_psa_resources ? 1 : 0
 
   source  = "terraform-google-modules/sql-db/google//modules/private_service_access"
   version = "26.2.2"
@@ -76,7 +76,7 @@ module "cloudsql-postgresql" {
     ssl_mode                      = "ENCRYPTED_ONLY"
     authorized_networks           = var.cloudsql.allowed_ip_ranges
     ipv4_enabled                  = each.value.public_ip_enabled
-    private_network               = local.cluster_psa_enabled[each.key] ? google_compute_network.psa[0].id : null
+    private_network               = local.cluster_psa_enabled[each.key] ? local.psa_network_id : null
     psc_enabled                   = local.cluster_psc_enabled[each.key]
     psc_allowed_consumer_projects = local.cluster_psc_enabled[each.key] ? [data.google_project.platform_project.number] : []
   }

--- a/infra/cloudsql/skeleton/infrastructure/code/modules/cloudsql/variables.tf
+++ b/infra/cloudsql/skeleton/infrastructure/code/modules/cloudsql/variables.tf
@@ -17,10 +17,11 @@ variable "region" {
 variable "cloudsql" {
   description = "Cloud SQL configuration"
   type = object({
-    enabled           = bool
-    psa_enabled       = optional(bool, false)
-    psc_enabled       = optional(bool, false)
-    allowed_ip_ranges = optional(list(map(string)), [])
+    enabled              = bool
+    psa_enabled          = optional(bool, false)
+    manage_psa_resources = optional(bool)
+    psc_enabled          = optional(bool, false)
+    allowed_ip_ranges    = optional(list(map(string)), [])
     monitoring = optional(object({
       notification_emails = optional(list(string), [])
       thresholds = optional(object({
@@ -112,8 +113,8 @@ variable "cloudsql" {
   }
 
   validation {
-    condition     = !try(var.cloudsql.ids.enabled, false) || try(var.cloudsql.psa_enabled, false)
-    error_message = "cloudsql.ids.enabled requires cloudsql.psa_enabled because Cloud IDS mirrors the PSA VPC."
+    condition     = !try(var.cloudsql.ids.enabled, false) || (try(var.cloudsql.psa_enabled, false) && coalesce(try(var.cloudsql.manage_psa_resources, null), true))
+    error_message = "cloudsql.ids.enabled requires cloudsql.psa_enabled and managed PSA resources because Cloud IDS mirrors the PSA VPC."
   }
 
   validation {


### PR DESCRIPTION
## Summary
- add optional cloudsql.manage_psa_resources to the Cloud SQL infra template
- allow Cloud SQL instances to attach to an existing/shared PSA VPC without this module creating or managing PSA resources
- keep Cloud SQL private_network stable when psa_enabled remains true
- require managed PSA resources for Cloud IDS
- document the shared/external PSA setup use case

## Validation
- tofu fmt -recursive
- terragrunt hcl fmt --check
- tofu init -backend=false && tofu validate

## Notes
This supports cases where multiple infra apps in the same project share a single Private Service Access setup managed elsewhere, while still allowing the normal default behavior where this module manages its own PSA VPC and connection.