### PR TITLE
Fix generated Next.js and Go security findings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,17 +148,30 @@ build image and `eclipse-temurin:NN-jre-noble` runtime image in `skeleton/Docker
 test Dockerfiles to the same JDK version. Gradle 9+ has no alpine variant for JDK 25 — use
 `-noble` (Ubuntu) instead.
 
-#### nextjs/web and static/nextra
+#### nextjs/web
+
+The package name is intentionally the stable private name `app`. Yarn 4 sorts workspace entries
+by package name, so rendering `{{ name }}` into both `package.json` and `yarn.lock` would make the
+generated lockfile non-canonical for some application names and break immutable installs.
+
+Update dependencies directly:
+
+```bash
+cd nextjs/web/skeleton
+npx npm-check-updates -u
+yarn install
+```
+
+#### static/nextra
 
 `package.json` contains `"name": "{{ name }}"` which is not a valid npm name — substitute temporarily:
 
 ```bash
-cd <template>/skeleton
+cd static/nextra/skeleton
 sed -i 's/"name": "{{ name }}"/"name": "app"/' package.json
 npx npm-check-updates -u
 yarn install
 sed -i 's/"name": "app"/"name": "{{ name }}"/' package.json
-# nextjs/web uses Yarn 4, so restore app@workspace:. to {{ name }}@workspace:. in yarn.lock too.
 ```
 
 When updating dependencies, always regenerate the lockfile(s) so transitive dependencies also
@@ -186,8 +199,8 @@ continues to use Yarn 1 frozen-lockfile installs.
 > newer version builds successfully.
 
 For `nextjs/web` and `static/nextra` — also update `p2p/tests/functional/package.json` (no
-`{{ name }}` substitution needed; for `static/nextra`, temporarily set parent `package.json`
-`name` to a valid value so `yarn install` can run):
+`{{ name }}` substitution needed; for `static/nextra`, temporarily set the parent
+`package.json` name to a valid value so `yarn install` can run):
 
 ```bash
 # nextjs/web:
@@ -429,12 +442,15 @@ ENTRYPOINT ["echo"]
 CMD ["### extended tests not implemented ###"]
 ```
 
-#### 8. Handle `{{ name }}` in lockfiles
+#### 8. Handle project names in lockfiles
 
-If the package manager embeds the project name in its lockfile (e.g. `uv.lock` and the Yarn 4
-lockfile in `nextjs/web`), store `{{ name }}` in the lockfile too — the template engine
-substitutes all files in `skeleton/`.
-Add dependency-update instructions to this file following the `python/web` pattern.
+If canonical lockfile ordering depends on the project name, use a stable valid project name in
+both the manifest and lockfile. The Yarn 4 lockfile in `nextjs/web` uses this approach because
+rendering its workspace name after lockfile generation can invalidate the ordering.
+
+If replacing the project name does not affect canonical ordering, store `{{ name }}` in the
+manifest and lockfile so the template engine substitutes both. `uv.lock` uses this approach.
+Add dependency-update instructions to this file following the relevant existing pattern.
 
 Lockfiles that do not embed the project name (e.g. the Yarn 1 lockfile in `static/nextra` and
 `go.sum`) need no special handling. Always commit the lockfile; do not `.gitignore` it.

--- a/Makefile
+++ b/Makefile
@@ -34,3 +34,4 @@ templates-validate:
 	fi ; \
 	exit "$${ERRVAL}"
 	@bash tests/template_docs_test.sh
+	@bash tests/nextjs_template_test.sh

--- a/docker/web/skeleton/p2p/tests/extended/go.mod
+++ b/docker/web/skeleton/p2p/tests/extended/go.mod
@@ -16,6 +16,6 @@ require (
 	github.com/hashicorp/go-memdb v1.3.5 // indirect
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
-	golang.org/x/net v0.55.0 // indirect
-	golang.org/x/sys v0.45.0 // indirect
+	golang.org/x/net v0.56.0 // indirect
+	golang.org/x/sys v0.46.0 // indirect
 )

--- a/docker/web/skeleton/p2p/tests/extended/go.sum
+++ b/docker/web/skeleton/p2p/tests/extended/go.sum
@@ -51,10 +51,10 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
-golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
-golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
-golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/net v0.56.0 h1:Rw8j/hFzGvJUZwNBXnAtf5sVDVt+65SK2C7IxCxZt5o=
+golang.org/x/net v0.56.0/go.mod h1:D3Ku6r+V6JROoZK144D2XfMHFcMq/0zSfLelVTCFKec=
+golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
+golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/time v0.12.0 h1:ScB/8o8olJvc+CQPWrK3fPZNfh7qgwCrY0zJmoEQLSE=
 golang.org/x/time v0.12.0/go.mod h1:CDIdPxbZBQxdj6cxyCIdrNogrJKMJ7pr37NYpMcMDSg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/docker/web/skeleton/p2p/tests/functional/go.mod
+++ b/docker/web/skeleton/p2p/tests/functional/go.mod
@@ -16,6 +16,6 @@ require (
 	github.com/hashicorp/go-memdb v1.3.5 // indirect
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
-	golang.org/x/net v0.55.0 // indirect
-	golang.org/x/sys v0.45.0 // indirect
+	golang.org/x/net v0.56.0 // indirect
+	golang.org/x/sys v0.46.0 // indirect
 )

--- a/docker/web/skeleton/p2p/tests/functional/go.sum
+++ b/docker/web/skeleton/p2p/tests/functional/go.sum
@@ -51,10 +51,10 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
-golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
-golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
-golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/net v0.56.0 h1:Rw8j/hFzGvJUZwNBXnAtf5sVDVt+65SK2C7IxCxZt5o=
+golang.org/x/net v0.56.0/go.mod h1:D3Ku6r+V6JROoZK144D2XfMHFcMq/0zSfLelVTCFKec=
+golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
+golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/time v0.12.0 h1:ScB/8o8olJvc+CQPWrK3fPZNfh7qgwCrY0zJmoEQLSE=
 golang.org/x/time v0.12.0/go.mod h1:CDIdPxbZBQxdj6cxyCIdrNogrJKMJ7pr37NYpMcMDSg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/docker/web/skeleton/p2p/tests/integration/go.mod
+++ b/docker/web/skeleton/p2p/tests/integration/go.mod
@@ -16,6 +16,6 @@ require (
 	github.com/hashicorp/go-memdb v1.3.5 // indirect
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
-	golang.org/x/net v0.55.0 // indirect
-	golang.org/x/sys v0.45.0 // indirect
+	golang.org/x/net v0.56.0 // indirect
+	golang.org/x/sys v0.46.0 // indirect
 )

--- a/docker/web/skeleton/p2p/tests/integration/go.sum
+++ b/docker/web/skeleton/p2p/tests/integration/go.sum
@@ -51,10 +51,10 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
-golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
-golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
-golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/net v0.56.0 h1:Rw8j/hFzGvJUZwNBXnAtf5sVDVt+65SK2C7IxCxZt5o=
+golang.org/x/net v0.56.0/go.mod h1:D3Ku6r+V6JROoZK144D2XfMHFcMq/0zSfLelVTCFKec=
+golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
+golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/time v0.12.0 h1:ScB/8o8olJvc+CQPWrK3fPZNfh7qgwCrY0zJmoEQLSE=
 golang.org/x/time v0.12.0/go.mod h1:CDIdPxbZBQxdj6cxyCIdrNogrJKMJ7pr37NYpMcMDSg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go/web/skeleton/p2p/tests/functional/go.mod
+++ b/go/web/skeleton/p2p/tests/functional/go.mod
@@ -16,6 +16,6 @@ require (
 	github.com/hashicorp/go-memdb v1.3.5 // indirect
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
-	golang.org/x/net v0.55.0 // indirect
-	golang.org/x/sys v0.45.0 // indirect
+	golang.org/x/net v0.56.0 // indirect
+	golang.org/x/sys v0.46.0 // indirect
 )

--- a/go/web/skeleton/p2p/tests/functional/go.sum
+++ b/go/web/skeleton/p2p/tests/functional/go.sum
@@ -51,10 +51,10 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
-golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
-golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
-golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/net v0.56.0 h1:Rw8j/hFzGvJUZwNBXnAtf5sVDVt+65SK2C7IxCxZt5o=
+golang.org/x/net v0.56.0/go.mod h1:D3Ku6r+V6JROoZK144D2XfMHFcMq/0zSfLelVTCFKec=
+golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
+golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/time v0.12.0 h1:ScB/8o8olJvc+CQPWrK3fPZNfh7qgwCrY0zJmoEQLSE=
 golang.org/x/time v0.12.0/go.mod h1:CDIdPxbZBQxdj6cxyCIdrNogrJKMJ7pr37NYpMcMDSg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go/web/skeleton/p2p/tests/integration/go.mod
+++ b/go/web/skeleton/p2p/tests/integration/go.mod
@@ -16,6 +16,6 @@ require (
 	github.com/hashicorp/go-memdb v1.3.5 // indirect
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
-	golang.org/x/net v0.55.0 // indirect
-	golang.org/x/sys v0.45.0 // indirect
+	golang.org/x/net v0.56.0 // indirect
+	golang.org/x/sys v0.46.0 // indirect
 )

--- a/go/web/skeleton/p2p/tests/integration/go.sum
+++ b/go/web/skeleton/p2p/tests/integration/go.sum
@@ -51,10 +51,10 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
-golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
-golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
-golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/net v0.56.0 h1:Rw8j/hFzGvJUZwNBXnAtf5sVDVt+65SK2C7IxCxZt5o=
+golang.org/x/net v0.56.0/go.mod h1:D3Ku6r+V6JROoZK144D2XfMHFcMq/0zSfLelVTCFKec=
+golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
+golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/time v0.12.0 h1:ScB/8o8olJvc+CQPWrK3fPZNfh7qgwCrY0zJmoEQLSE=
 golang.org/x/time v0.12.0/go.mod h1:CDIdPxbZBQxdj6cxyCIdrNogrJKMJ7pr37NYpMcMDSg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/nextjs/web/skeleton/.p2p-security-ignore.yaml
+++ b/nextjs/web/skeleton/.p2p-security-ignore.yaml
@@ -1,0 +1,10 @@
+version: 1
+
+source:
+  secrets:
+    - id: 4521b49fbafd22f6c1c2644d4a79898c75771a9c1673b692b8633b16933ea7e5
+      path: yarn.lock
+      reason: False positive in Yarn lockfile checksum; no credential material.
+    - id: 4904adc4778dc1f1415726bdef669c0e4896208765c723485be778b3f75665ee
+      path: yarn.lock
+      reason: False positive in Yarn lockfile checksum; no credential material.

--- a/nextjs/web/skeleton/package.json
+++ b/nextjs/web/skeleton/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "{{ name }}",
+  "name": "app",
   "version": "0.1.0",
   "private": true,
   "packageManager": "yarn@4.17.1",

--- a/nextjs/web/skeleton/yarn.lock
+++ b/nextjs/web/skeleton/yarn.lock
@@ -2772,6 +2772,41 @@ __metadata:
   languageName: node
   linkType: hard
 
+"app@workspace:.":
+  version: 0.0.0-use.local
+  resolution: "app@workspace:."
+  dependencies:
+    "@eslint/eslintrc": "npm:^3.3.5"
+    "@radix-ui/react-dropdown-menu": "npm:^2.1.18"
+    "@radix-ui/react-slot": "npm:^1.3.0"
+    "@tailwindcss/postcss": "npm:^4.3.1"
+    "@testing-library/dom": "npm:^10.4.1"
+    "@testing-library/jest-dom": "npm:^6.9.1"
+    "@testing-library/react": "npm:^16.3.2"
+    "@types/jest": "npm:^30.0.0"
+    "@types/node": "npm:^26.0.0"
+    "@types/react": "npm:19.2.17"
+    "@types/react-dom": "npm:19.2.3"
+    class-variance-authority: "npm:^0.7.1"
+    clsx: "npm:^2.1.1"
+    eslint: "npm:^10.5.0"
+    eslint-config-next: "npm:16.2.9"
+    jest: "npm:^30.4.2"
+    jest-environment-jsdom: "npm:^30.4.1"
+    lucide-react: "npm:^1.21.0"
+    next: "npm:16.2.9"
+    next-themes: "npm:^0.4.6"
+    prom-client: "npm:^15.1.3"
+    react: "npm:19.2.7"
+    react-dom: "npm:19.2.7"
+    tailwind-merge: "npm:^3.6.0"
+    tailwindcss: "npm:^4.3.1"
+    ts-node: "npm:^10.9.2"
+    tw-animate-css: "npm:^1.4.0"
+    typescript: "npm:^6.0.3"
+  languageName: unknown
+  linkType: soft
+
 "arg@npm:^4.1.0":
   version: 4.1.3
   resolution: "arg@npm:4.1.3"
@@ -8093,38 +8128,3 @@ __metadata:
   checksum: 10c0/7ea31b558e88f9faf44f31dd185e2e1cbf51fed3081787fb96cc2534749b50c0acfc6da7f0922a7353ed092dd358c7d50c28ea96c94d04af64191bd33152eca3
   languageName: node
   linkType: hard
-
-"{{ name }}@workspace:.":
-  version: 0.0.0-use.local
-  resolution: "{{ name }}@workspace:."
-  dependencies:
-    "@eslint/eslintrc": "npm:^3.3.5"
-    "@radix-ui/react-dropdown-menu": "npm:^2.1.18"
-    "@radix-ui/react-slot": "npm:^1.3.0"
-    "@tailwindcss/postcss": "npm:^4.3.1"
-    "@testing-library/dom": "npm:^10.4.1"
-    "@testing-library/jest-dom": "npm:^6.9.1"
-    "@testing-library/react": "npm:^16.3.2"
-    "@types/jest": "npm:^30.0.0"
-    "@types/node": "npm:^26.0.0"
-    "@types/react": "npm:19.2.17"
-    "@types/react-dom": "npm:19.2.3"
-    class-variance-authority: "npm:^0.7.1"
-    clsx: "npm:^2.1.1"
-    eslint: "npm:^10.5.0"
-    eslint-config-next: "npm:16.2.9"
-    jest: "npm:^30.4.2"
-    jest-environment-jsdom: "npm:^30.4.1"
-    lucide-react: "npm:^1.21.0"
-    next: "npm:16.2.9"
-    next-themes: "npm:^0.4.6"
-    prom-client: "npm:^15.1.3"
-    react: "npm:19.2.7"
-    react-dom: "npm:19.2.7"
-    tailwind-merge: "npm:^3.6.0"
-    tailwindcss: "npm:^4.3.1"
-    ts-node: "npm:^10.9.2"
-    tw-animate-css: "npm:^1.4.0"
-    typescript: "npm:^6.0.3"
-  languageName: unknown
-  linkType: soft

--- a/tests/nextjs_template_test.sh
+++ b/tests/nextjs_template_test.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+package_file="nextjs/web/skeleton/package.json"
+lock_file="nextjs/web/skeleton/yarn.lock"
+failures=0
+
+if ! grep -qE '^  "name": "app",$' "$package_file"; then
+  printf 'FAIL: %s: Next.js must use the stable package name "app"\n' "$package_file"
+  failures=$((failures + 1))
+fi
+
+if grep -q '{{ name }}' "$package_file" "$lock_file"; then
+  printf 'FAIL: Next.js package and lockfile names must not be rendered from {{ name }}\n'
+  failures=$((failures + 1))
+fi
+
+if ! grep -qE '^"app@workspace:\.":$' "$lock_file"; then
+  printf 'FAIL: %s: missing app@workspace:. entry\n' "$lock_file"
+  failures=$((failures + 1))
+fi
+
+if [[ "$failures" -gt 0 ]]; then
+  exit 1
+fi
+
+printf 'Next.js template checks passed\n'


### PR DESCRIPTION
## Summary
- use a stable private Next.js package name so rendered Yarn 4 lockfiles remain canonical under immutable installs
- add a validation guard and correct the dependency-maintenance guidance
- upgrade `golang.org/x/net` to `v0.56.0` and `golang.org/x/sys` to `v0.46.0` in the five affected Go and Docker test modules
- record the two FlatIO checksum false positives in the Next.js template using the existing directory-scoped P2P security-ignore contract

## Testing
- `make templates-validate`
- `yarn install --immutable --mode=skip-build`
- `go mod verify` in all five updated modules
- validated both checksum finding IDs through the P2P scoped-ignore parser with zero active findings
- rendered `nextjs-web` as `reference-nextjs-web`
- completed the rendered linux/amd64 Docker build, including Jest and Next.js production build

Service-dependent functional and integration suites were not run locally; template CD runs the generated reference P2P workflows after merge.