### PR TITLE
Fix Java template tar vulnerability

### DIFF
--- a/java/web/skeleton/Dockerfile
+++ b/java/web/skeleton/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update \
   ncurses-bin=6.4+20240113-1ubuntu2.1 \
   openssl=3.0.13-0ubuntu3.11 \
   perl-base=5.38.2-3.2ubuntu0.3 \
-  tar=1.35+dfsg-3ubuntu0.2 \
+  tar=1.35+dfsg-3ubuntu0.3 \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary
- update the Java web runtime tar package to `1.35+dfsg-3ubuntu0.3`
- remediate CVE-2026-5704 in newly generated Java application images

## Verification
- `make templates-validate`
- rendered the `java-web` template with `corectl`
- built the rendered Java 26 image with `--pull --no-cache`
- rendered application build and unit tests
- Hadolint
- Trivy image scan: zero fixed vulnerabilities