### PR TITLE
Make Cloud SQL privilege grants fail closed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,3 +36,4 @@ templates-validate:
 	@bash tests/template_docs_test.sh
 	@bash tests/java_template_test.sh
 	@bash tests/nextjs_template_test.sh
+	@bash tests/cloudsql_template_test.sh

--- a/infra/cloudsql/skeleton/infrastructure/code/modules/cloudsql/README.md
+++ b/infra/cloudsql/skeleton/infrastructure/code/modules/cloudsql/README.md
@@ -218,7 +218,7 @@ When IAM users are configured for any database:
    - `roles/cloudsql.instanceUser` - Allows authenticating to Cloud SQL instances using IAM
    - `roles/serviceusage.serviceUsageConsumer` - Allows cross-project access (platform → infrastructure)
 3. **Comprehensive PostgreSQL privileges** are automatically granted to each IAM user for **only the databases they are specified in**
-4. The privilege grants are performed using `cloud-sql-proxy` and `psql` during `terraform apply` via a `null_resource` provisioner
+4. The privilege grants are performed using `cloud-sql-proxy` and `psql` during `terraform apply` via a `null_resource` provisioner.
 
 **Privileges Granted** (per database):
 - `ALL PRIVILEGES` on the database (includes CONNECT, CREATE, TEMPORARY)
@@ -230,7 +230,8 @@ When IAM users are configured for any database:
 - Optionally, additional PostgreSQL roles can be granted to IAM users by specifying the `roles` list in the IAM user configuration
 - Common built-in roles include: `pg_read_all_data`, `pg_write_all_data`, `pg_read_all_settings`, `pg_read_all_stats`, `pg_monitor`, `pg_signal_backend`
 - Roles are granted using `GRANT "<role>" TO "<iam_user>";` during the provisioning process
-- If a role doesn't exist or is already granted, the process continues with a warning
+- All database and role grants run in one transaction. If any requested grant fails, the transaction is rolled back and the infrastructure apply fails.
+- Granting an existing role is idempotent. Removing a role from configuration does not revoke an existing membership.
 
 **Note**: PostgreSQL truncates IAM usernames to end at `.iam` due to the 63-character username limit. For example, `service-account@project.iam.gserviceaccount.com` becomes `service-account@project.iam` in the database.
 

--- a/infra/cloudsql/skeleton/infrastructure/code/modules/cloudsql/main.tf
+++ b/infra/cloudsql/skeleton/infrastructure/code/modules/cloudsql/main.tf
@@ -167,105 +167,15 @@ resource "null_resource" "grant_iam_user_privileges" {
 
   provisioner "local-exec" {
     interpreter = ["/bin/bash", "-c"]
-    command     = <<-EOT
-      set -e
-
-      # Ensure proxy process is cleaned up on exit or error
-      # EXIT trap works with set -e to catch both normal exit and errors
-      cleanup_proxy() {
-        if [ ! -z "$PROXY_PID" ]; then
-          echo "Cleaning up Cloud SQL Proxy (PID: $PROXY_PID)..."
-          kill $PROXY_PID 2>/dev/null || true
-          wait $PROXY_PID 2>/dev/null || true
-        fi
-      }
-      trap cleanup_proxy EXIT
-
-      echo "Granting privileges on database '${each.value.database}' to '${each.value.iam_user}'..."
-
-      # Get connection name for Cloud SQL Proxy
-      CONNECTION_NAME=$(gcloud sql instances describe ${each.value.cluster_name} \
-        --project=${var.infrastructure_project_id} \
-        --format='value(connectionName)')
-
-      # Start Cloud SQL Proxy in background on random port with retry logic
-      MAX_PORT_RETRIES=10
-      PROXY_STARTED=false
-
-      for port_attempt in $(seq 1 $MAX_PORT_RETRIES); do
-        PROXY_PORT=$((30000 + RANDOM % 10000))
-        echo "Attempt $port_attempt: Starting Cloud SQL Proxy on port $PROXY_PORT..."
-
-        # Start proxy and capture output
-        cloud-sql-proxy "$CONNECTION_NAME" --port=$PROXY_PORT &
-        PROXY_PID=$!
-
-        # Give proxy a moment to fail if port is in use
-        sleep 1
-
-        # Check if proxy is still running (it exits immediately if port is in use)
-        if kill -0 $PROXY_PID 2>/dev/null; then
-          PROXY_STARTED=true
-          echo "Cloud SQL Proxy started successfully on port $PROXY_PORT"
-          break
-        else
-          echo "Port $PROXY_PORT was in use, trying another port..."
-          PROXY_PID=""
-        fi
-      done
-
-      if [ "$PROXY_STARTED" = false ]; then
-        echo "ERROR: Failed to start Cloud SQL Proxy after $MAX_PORT_RETRIES attempts"
-        exit 1
-      fi
-
-      # Wait for proxy to be ready with retry logic (max 30 seconds)
-      echo "Waiting for Cloud SQL Proxy to be ready..."
-      for i in $(seq 1 30); do
-        if pg_isready -h 127.0.0.1 -p $PROXY_PORT -U postgres -q 2>/dev/null; then
-          echo "Cloud SQL Proxy is ready after $i seconds"
-          break
-        fi
-        if [ $i -eq 30 ]; then
-          echo "ERROR: Cloud SQL Proxy failed to become ready after 30 seconds"
-          exit 1
-        fi
-        sleep 1
-      done
-
-      # Execute SQL via psql (password provided via PGPASSWORD environment variable)
-      # Note: Some grants may fail if postgres user doesn't own certain objects (e.g., flyway_schema_history)
-      # This is expected and acceptable - psql will continue without ON_ERROR_STOP
-      echo "Executing privilege grants..."
-      psql -h 127.0.0.1 -p $PROXY_PORT -U postgres -d ${each.value.database} \
-        -c "GRANT ALL PRIVILEGES ON DATABASE \"${each.value.database}\" TO \"${each.value.iam_user}\";" \
-        -c "GRANT ALL PRIVILEGES ON SCHEMA public TO \"${each.value.iam_user}\";" \
-        -c "GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO \"${each.value.iam_user}\";" \
-        -c "GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO \"${each.value.iam_user}\";" \
-        -c "GRANT ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA public TO \"${each.value.iam_user}\";" \
-        -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL PRIVILEGES ON TABLES TO \"${each.value.iam_user}\";" \
-        -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL PRIVILEGES ON SEQUENCES TO \"${each.value.iam_user}\";" \
-        -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL PRIVILEGES ON FUNCTIONS TO \"${each.value.iam_user}\";"
-
-      # Grant PostgreSQL roles if specified
-      ROLES="${join(",", each.value.roles)}"
-      if [ ! -z "$ROLES" ]; then
-        echo "Granting PostgreSQL roles to '${each.value.iam_user}': $ROLES"
-        IFS=',' read -ra ROLE_ARRAY <<< "$ROLES"
-        for role in "$${ROLE_ARRAY[@]}"; do
-          if [ ! -z "$role" ]; then
-            echo "  Granting role: $role"
-            psql -h 127.0.0.1 -p $PROXY_PORT -U postgres -d ${each.value.database} \
-              -c "GRANT \"$role\" TO \"${each.value.iam_user}\";" || echo "  Warning: Failed to grant role $role (may not exist or already granted)"
-          fi
-        done
-      fi
-
-      echo "Privileges granted successfully (errors for non-postgres owned objects are expected)"
-    EOT
+    command     = "/bin/bash \"${path.module}/scripts/grant-iam-user-privileges.sh\""
 
     environment = {
-      PGPASSWORD = nonsensitive(random_password.cloudsql_initial_password.result)
+      CLUSTER_NAME   = each.value.cluster_name
+      DATABASE_NAME  = each.value.database
+      IAM_USER       = each.value.iam_user
+      PGPASSWORD     = nonsensitive(random_password.cloudsql_initial_password.result)
+      POSTGRES_ROLES = jsonencode(each.value.roles)
+      PROJECT_ID     = var.infrastructure_project_id
     }
   }
 
@@ -291,18 +201,23 @@ resource "null_resource" "apply_user_password_policy" {
   provisioner "local-exec" {
     interpreter = ["/bin/bash", "-c"]
     command     = <<-EOT
-      set -e
+      set -euo pipefail
 
-      echo "Applying password policy to postgres user on instance '${each.key}-${var.environment}-cluster'..."
+      echo "Applying password policy to postgres user on instance '$CLUSTER_NAME'..."
 
       gcloud sql users set-password-policy postgres \
-        --instance=${each.key}-${var.environment}-cluster \
-        --project=${var.infrastructure_project_id} \
-        --host=% \
+        --instance="$CLUSTER_NAME" \
+        --project="$PROJECT_ID" \
+        --host="%" \
         --password-policy-enable-password-verification
 
       echo "Password verification enabled for postgres user"
     EOT
+
+    environment = {
+      CLUSTER_NAME = "${each.key}-${var.environment}-cluster"
+      PROJECT_ID   = var.infrastructure_project_id
+    }
   }
 
   depends_on = [

--- a/infra/cloudsql/skeleton/infrastructure/code/modules/cloudsql/scripts/grant-iam-user-privileges.sh
+++ b/infra/cloudsql/skeleton/infrastructure/code/modules/cloudsql/scripts/grant-iam-user-privileges.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${CLUSTER_NAME:?CLUSTER_NAME is required}"
+: "${DATABASE_NAME:?DATABASE_NAME is required}"
+: "${IAM_USER:?IAM_USER is required}"
+: "${PGPASSWORD:?PGPASSWORD is required}"
+: "${POSTGRES_ROLES:?POSTGRES_ROLES is required}"
+: "${PROJECT_ID:?PROJECT_ID is required}"
+
+PROXY_PID=""
+
+cleanup_proxy() {
+  if [[ -n "$PROXY_PID" ]]; then
+    echo "Cleaning up Cloud SQL Proxy (PID: $PROXY_PID)..."
+    kill "$PROXY_PID" 2>/dev/null || true
+    wait "$PROXY_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup_proxy EXIT
+
+echo "Granting privileges on database '$DATABASE_NAME' to '$IAM_USER'..."
+
+CONNECTION_NAME=$(gcloud sql instances describe "$CLUSTER_NAME" \
+  --project="$PROJECT_ID" \
+  --format="value(connectionName)")
+
+MAX_PORT_RETRIES=10
+PROXY_STARTED=false
+
+for port_attempt in $(seq 1 "$MAX_PORT_RETRIES"); do
+  PROXY_PORT=$((30000 + RANDOM % 10000))
+  echo "Attempt $port_attempt: Starting Cloud SQL Proxy on port $PROXY_PORT..."
+
+  cloud-sql-proxy "$CONNECTION_NAME" --port="$PROXY_PORT" &
+  PROXY_PID=$!
+  sleep 1
+
+  if kill -0 "$PROXY_PID" 2>/dev/null; then
+    PROXY_STARTED=true
+    echo "Cloud SQL Proxy started successfully on port $PROXY_PORT"
+    break
+  fi
+
+  echo "Port $PROXY_PORT was in use, trying another port..."
+  PROXY_PID=""
+done
+
+if [[ "$PROXY_STARTED" == false ]]; then
+  echo "ERROR: Failed to start Cloud SQL Proxy after $MAX_PORT_RETRIES attempts"
+  exit 1
+fi
+
+echo "Waiting for Cloud SQL Proxy to be ready..."
+for attempt in $(seq 1 30); do
+  if pg_isready --host=127.0.0.1 --port="$PROXY_PORT" --username=postgres --quiet 2>/dev/null; then
+    echo "Cloud SQL Proxy is ready after $attempt seconds"
+    break
+  fi
+  if [[ "$attempt" -eq 30 ]]; then
+    echo "ERROR: Cloud SQL Proxy failed to become ready after 30 seconds"
+    exit 1
+  fi
+  sleep 1
+done
+
+echo "Executing privilege grants..."
+psql \
+  --host=127.0.0.1 \
+  --port="$PROXY_PORT" \
+  --username=postgres \
+  --dbname="$DATABASE_NAME" \
+  --set=ON_ERROR_STOP=1 \
+  --set=database="$DATABASE_NAME" \
+  --set=iam_user="$IAM_USER" \
+  --set=roles="$POSTGRES_ROLES" <<'SQL'
+BEGIN;
+GRANT ALL PRIVILEGES ON DATABASE :"database" TO :"iam_user";
+GRANT ALL PRIVILEGES ON SCHEMA public TO :"iam_user";
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO :"iam_user";
+GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO :"iam_user";
+GRANT ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA public TO :"iam_user";
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL PRIVILEGES ON TABLES TO :"iam_user";
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL PRIVILEGES ON SEQUENCES TO :"iam_user";
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL PRIVILEGES ON FUNCTIONS TO :"iam_user";
+
+SELECT format('GRANT %I TO %I', role_name, :'iam_user')
+FROM json_array_elements_text(:'roles'::json) AS roles(role_name)
+\gexec
+COMMIT;
+SQL
+
+echo "Privileges granted successfully"

--- a/tests/cloudsql_template_test.sh
+++ b/tests/cloudsql_template_test.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+module="infra/cloudsql/skeleton/infrastructure/code/modules/cloudsql"
+main_tf="$module/main.tf"
+grant_script="$module/scripts/grant-iam-user-privileges.sh"
+failures=0
+
+check_file_contains() {
+  local file=$1
+  local pattern=$2
+  local message=$3
+
+  if ! grep -qE -- "$pattern" "$file"; then
+    printf 'FAIL: %s: %s\n' "$file" "$message"
+    failures=$((failures + 1))
+  fi
+}
+
+check_file_not_contains() {
+  local file=$1
+  local pattern=$2
+  local message=$3
+
+  if grep -qE -- "$pattern" "$file"; then
+    printf 'FAIL: %s: %s\n' "$file" "$message"
+    failures=$((failures + 1))
+  fi
+}
+
+check_file_contains "$main_tf" 'scripts/grant-iam-user-privileges\.sh' "privilege grants must use the tested script"
+check_file_contains "$main_tf" 'POSTGRES_ROLES[[:space:]]+= jsonencode\(each\.value\.roles\)' "roles must pass through the environment as JSON"
+check_file_contains "$main_tf" 'grant_version = "v1"' "existing privilege resources must not be forced to rerun"
+check_file_contains "$main_tf" 'roles[[:space:]]+= join\(",", each\.value\.roles\)' "existing role triggers must remain unchanged"
+check_file_contains "$grant_script" '--set=ON_ERROR_STOP=1' "psql must stop on the first SQL error"
+check_file_contains "$grant_script" 'GRANT %I TO %I' "role grants must quote PostgreSQL identifiers"
+check_file_contains "$grant_script" '^BEGIN;$' "privilege grants must run in a transaction"
+check_file_contains "$grant_script" '^COMMIT;$' "privilege grants must commit atomically"
+check_file_not_contains "$main_tf" 'Failed to grant role.*Warning' "requested role grant failures must not be suppressed"
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+mkdir "$tmpdir/bin"
+
+cat >"$tmpdir/bin/gcloud" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$@" >"$MOCK_LOG_DIR/gcloud.args"
+printf '%s\n' 'project:region:instance'
+EOF
+
+cat >"$tmpdir/bin/cloud-sql-proxy" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$@" >"$MOCK_LOG_DIR/proxy.args"
+trap 'exit 0' TERM INT
+while true; do
+  /bin/sleep 1
+done
+EOF
+
+cat >"$tmpdir/bin/pg_isready" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$@" >"$MOCK_LOG_DIR/pg_isready.args"
+EOF
+
+cat >"$tmpdir/bin/psql" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$@" >"$MOCK_LOG_DIR/psql.args"
+cat >"$MOCK_LOG_DIR/psql.sql"
+exit "${PSQL_EXIT_CODE:-0}"
+EOF
+
+chmod +x "$tmpdir/bin/"*
+
+run_grant_script() {
+  env \
+    PATH="$tmpdir/bin:$PATH" \
+    MOCK_LOG_DIR="$tmpdir" \
+    CLUSTER_NAME='cluster name; touch injected' \
+    DATABASE_NAME='database "quoted"' \
+    IAM_USER='service"account@example.com' \
+    PGPASSWORD='not-a-real-secret' \
+    POSTGRES_ROLES='["role one","role\"two"]' \
+    PROJECT_ID='project with spaces' \
+    PSQL_EXIT_CODE="${1:-0}" \
+    bash "$grant_script"
+}
+
+run_grant_script >"$tmpdir/success.log"
+
+for expected in \
+  'cluster name; touch injected' \
+  '--project=project with spaces' \
+  '--format=value(connectionName)'; do
+  if ! grep -Fxq -- "$expected" "$tmpdir/gcloud.args"; then
+    printf 'FAIL: gcloud did not receive argument safely: %s\n' "$expected"
+    failures=$((failures + 1))
+  fi
+done
+
+for expected in \
+  '--dbname=database "quoted"' \
+  '--set=ON_ERROR_STOP=1' \
+  '--set=database=database "quoted"' \
+  '--set=iam_user=service"account@example.com' \
+  '--set=roles=["role one","role\"two"]'; do
+  if ! grep -Fxq -- "$expected" "$tmpdir/psql.args"; then
+    printf 'FAIL: psql did not receive argument safely: %s\n' "$expected"
+    failures=$((failures + 1))
+  fi
+done
+
+if grep -Fq 'service"account@example.com' "$tmpdir/psql.sql"; then
+  printf 'FAIL: IAM user was interpolated directly into SQL\n'
+  failures=$((failures + 1))
+fi
+
+if run_grant_script 42 >"$tmpdir/failure.log" 2>&1; then
+  printf 'FAIL: privilege script succeeded after psql failed\n'
+  failures=$((failures + 1))
+else
+  status=$?
+  if [[ "$status" -ne 42 ]]; then
+    printf 'FAIL: privilege script returned %s instead of psql status 42\n' "$status"
+    failures=$((failures + 1))
+  fi
+fi
+
+if grep -Fq 'Privileges granted successfully' "$tmpdir/failure.log"; then
+  printf 'FAIL: privilege script reported success after psql failed\n'
+  failures=$((failures + 1))
+fi
+
+if [[ "$failures" -gt 0 ]]; then
+  exit 1
+fi
+
+printf 'Cloud SQL template checks passed\n'


### PR DESCRIPTION
## Summary
- pass Cloud SQL, database, IAM user, and role values through the provisioner environment instead of interpolating them into shell and SQL
- quote PostgreSQL identifiers with `psql` variables and apply database and role grants in one transaction with `ON_ERROR_STOP`
- fail the infrastructure apply when a newly executed privilege grant fails instead of logging a warning and reporting success
- add mocked command-boundary, compatibility, and failure-propagation regression tests

## Compatibility
- no Cloud SQL configuration schema or proxy connectivity behavior changes
- the existing `null_resource` trigger expressions and `grant_version = "v1"` remain unchanged
- adopting this change does not replace or rerun existing privilege resources
- new resources, or resources independently replaced by an existing configuration trigger, use the fail-closed behavior
- role grants remain additive; removing a configured role does not revoke an existing membership

## Verification
- `make templates-validate`
- `tofu fmt -check -diff -recursive`
- `tofu init -backend=false && tofu validate`
- `terragrunt hcl fmt --check`
- `shellcheck tests/cloudsql_template_test.sh infra/cloudsql/skeleton/infrastructure/code/modules/cloudsql/scripts/grant-iam-user-privileges.sh`
- Cloud SQL runner Docker image build
- PostgreSQL 18 smoke test covering quoted identifiers, JSON role expansion, successful grants, and transaction rollback after a missing role